### PR TITLE
companion => _$impl and more precise capture

### DIFF
--- a/plugin/src/main/scala/org/scalamacros/paradise/reflect/Symbols.scala
+++ b/plugin/src/main/scala/org/scalamacros/paradise/reflect/Symbols.scala
@@ -19,7 +19,7 @@ trait Symbols {
       sym.isClass && {
         val MetaInlineClass = rootMirror.getClassIfDefined("scala.meta.internal.inline.inline")
         val applyMethod = sym.info.decl(TermName("apply"))
-        val applyImplMethod = sym.companionSymbol.info.decl(TermName("apply$impl"))
+        val applyImplMethod = sym.owner.info.decl(TermName(sym.name + "$impl")).info.decl(TermName("apply$impl"))
         applyMethod != NoSymbol && applyMethod.initialize.annotations.exists(_.tpe.typeSymbol == MetaInlineClass) && applyImplMethod.exists
       }
     }

--- a/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
+++ b/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
@@ -82,9 +82,16 @@ trait Expanders {
           }
           val metaSource = metaInput.parse[MetaSource].get
           def toMeta(tree: Tree): MetaTree = {
+            var minTree: MetaTree = null
             def captures(metaPos: MetaPosition, pos: Position) = metaPos.start.offset <= pos.point && pos.point <= metaPos.end.offset
-            metaSource.traverse { case metaTree: MetaTree if metaTree != metaSource && captures(metaTree.pos, tree.pos) => return metaTree }
-            sys.error(s"fatal error: couldn't find ${tree.pos.toString} in ${metaSource.show[MetaPositions]}")
+            def updatesMin(metaPos: MetaPosition, minPos: MetaPosition) = metaPos.end.offset - metaPos.start.offset < minPos.end.offset - minPos.start.offset
+            metaSource.traverse {
+              case metaTree: MetaTree if metaTree != metaSource && metaTree.is[scala.meta.Defn] && captures(metaTree.pos, tree.pos) && (minTree == null || updatesMin(metaTree.pos, minTree.pos)) =>
+                minTree = metaTree
+            }
+            if(minTree == null)
+              sys.error(s"fatal error: couldn't find ${tree.pos.toString} in ${metaSource.show[MetaPositions]}")
+            minTree
           }
 
           val treeInfo.Applied(Select(New(_), nme.CONSTRUCTOR), targs, vargss) = annotationTree

--- a/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
+++ b/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
@@ -118,7 +118,7 @@ trait Expanders {
             m_findMacroClassLoader.invoke(analyzer).asInstanceOf[ClassLoader]
           }
           val annotationModuleClass = {
-            try Class.forName(annotationSym.fullName + "$", true, classloader)
+            try Class.forName(annotationSym.fullName + "$impl$", true, classloader)
             catch {
               case ex: Throwable =>
               issueNormalTypeError(annotationTree, MacroAnnotationNotExpandedMessage)(namer.context)

--- a/tests/src/main/scala/annotations/new/main/Defs.scala
+++ b/tests/src/main/scala/annotations/new/main/Defs.scala
@@ -1,0 +1,20 @@
+package main
+
+import scala.annotation.compileTimeOnly
+import scala.meta._
+
+@compileTimeOnly("@printDef not expanded")
+class printDef extends scala.annotation.StaticAnnotation {
+  inline def apply(defn: Any) = meta {
+    assert(defn.is[Defn.Def])
+    q"println(${defn.toString})"
+  }
+}
+
+@compileTimeOnly("@printVal not expanded")
+class printVal extends scala.annotation.StaticAnnotation {
+  inline def apply(defn: Any) = meta {
+    assert(defn.is[Defn.Val])
+    q"println(${defn.toString})"
+  }
+}

--- a/tests/src/main/scala/annotations/new/main/Macros.scala
+++ b/tests/src/main/scala/annotations/new/main/Macros.scala
@@ -1,0 +1,15 @@
+package main
+
+import scala.annotation.compileTimeOnly
+import scala.meta._
+
+@compileTimeOnly("@main not expanded")
+class main extends scala.annotation.StaticAnnotation {
+  inline def apply(defn: Any) = meta {
+    val q"object $name { ..$stats }" = defn
+    val main = q"""
+      def main(args: Array[String]): Unit = { ..$stats }
+    """
+    q"object $name { $main }"
+  }
+}

--- a/tests/src/test/scala/annotations/new/main/PrintDefn.scala
+++ b/tests/src/test/scala/annotations/new/main/PrintDefn.scala
@@ -1,0 +1,9 @@
+package main
+
+object PrintDefn extends App {
+  @printDef
+  def Def = ???
+
+  @printVal
+  val Val = ???
+}

--- a/tests/src/test/scala/annotations/new/main/Test.scala
+++ b/tests/src/test/scala/annotations/new/main/Test.scala
@@ -1,0 +1,5 @@
+package main
+
+@main object Test {
+  println("hello world")
+}


### PR DESCRIPTION
This patch will fix following two problems:

1. #911a1bd is not complete: the synthesized module is not the companion but _$impl. This causes most of new macro annotations including `@main` cannot be expanded.
2. The current prototype captures too large meta trees
e.g. If we write `object Main { @mcr def foo = ??? }`, the whole tree is passed to `@mcr`, not only `def foo = ???`.