### PR TITLE
Support multiple expandees

### DIFF
--- a/plugin/src/main/scala/org/scalamacros/paradise/reflect/TreeInfo.scala
+++ b/plugin/src/main/scala/org/scalamacros/paradise/reflect/TreeInfo.scala
@@ -32,7 +32,7 @@ trait TreeInfo {
           val cdef = tree.asInstanceOf[ClassDef]
           val czippers = mods.annotations.map(ann => {
             val mods1 = mods.mapAnnotations(_ diff List(ann))
-            val annottee = PatchedSyntacticClassDef(mods1, name, tparams, constrMods, vparamss, earlyDefs, parents, selfdef, body)
+            val annottee = atPos(tree.pos)(PatchedSyntacticClassDef(mods1, name, tparams, constrMods, vparamss, earlyDefs, parents, selfdef, body))
             AnnotationZipper(ann, annottee, annottee)
           })
           if (!deep) czippers
@@ -41,20 +41,20 @@ trait TreeInfo {
               tparam <- tparams
               AnnotationZipper(ann, tparam1: TypeDef, _) <- loop(tparam, deep = false)
               tparams1 = tparams.updated(tparams.indexOf(tparam), tparam1)
-            } yield AnnotationZipper(ann, tparam1, PatchedSyntacticClassDef(mods, name, tparams1, constrMods, vparamss, earlyDefs, parents, selfdef, body))
+            } yield AnnotationZipper(ann, tparam1, atPos(tree.pos)(PatchedSyntacticClassDef(mods, name, tparams1, constrMods, vparamss, earlyDefs, parents, selfdef, body)))
             val vzippers = for {
               vparams <- vparamss
               vparam <- vparams
               AnnotationZipper(ann, vparam1: ValDef, _) <- loop(vparam, deep = false)
               vparams1 = vparams.updated(vparams.indexOf(vparam), vparam1)
               vparamss1 = vparamss.updated(vparamss.indexOf(vparams), vparams1)
-            } yield AnnotationZipper(ann, vparam1, PatchedSyntacticClassDef(mods, name, tparams, constrMods, vparamss1, earlyDefs, parents, selfdef, body))
+            } yield AnnotationZipper(ann, vparam1, atPos(tree.pos)(PatchedSyntacticClassDef(mods, name, tparams, constrMods, vparamss1, earlyDefs, parents, selfdef, body)))
             czippers ++ tzippers ++ vzippers
           }
         case SyntacticTraitDef(mods, name, tparams, earlyDefs, parents, selfdef, body) =>
           val tdef = tree.asInstanceOf[ClassDef]
           val czippers = mods.annotations.map(ann => {
-            val annottee = tdef.copy(mods = mods.mapAnnotations(_ diff List(ann)))
+            val annottee = atPos(tree.pos)(tdef.copy(mods = mods.mapAnnotations(_ diff List(ann))))
             AnnotationZipper(ann, annottee, annottee)
           })
           if (!deep) czippers
@@ -63,17 +63,17 @@ trait TreeInfo {
               tparam <- tparams
               AnnotationZipper(ann, tparam1: TypeDef, _) <- loop(tparam, deep = false)
               tparams1 = tparams.updated(tparams.indexOf(tparam), tparam1)
-            } yield AnnotationZipper(ann, tparam1, tdef.copy(tparams = tparams1))
+            } yield AnnotationZipper(ann, tparam1, atPos(tree.pos)(tdef.copy(tparams = tparams1)))
             czippers ++ tzippers
           }
         case mdef @ ModuleDef(mods, _, _) =>
           mods.annotations.map(ann => {
-            val annottee = mdef.copy(mods = mods.mapAnnotations(_ diff List(ann)))
+            val annottee = atPos(tree.pos)(mdef.copy(mods = mods.mapAnnotations(_ diff List(ann))))
             AnnotationZipper(ann, annottee, annottee)
           })
         case ddef @ DefDef(mods, _, tparams, vparamss, _, _) =>
           val dzippers = mods.annotations.map(ann => {
-            val annottee = ddef.copy(mods = mods.mapAnnotations(_ diff List(ann)))
+            val annottee = atPos(tree.pos)(ddef.copy(mods = mods.mapAnnotations(_ diff List(ann))))
             AnnotationZipper(ann, annottee, annottee)
           })
           if (!deep) dzippers
@@ -82,24 +82,24 @@ trait TreeInfo {
               tparam <- tparams
               AnnotationZipper(ann, tparam1: TypeDef, _) <- loop(tparam, deep = false)
               tparams1 = tparams.updated(tparams.indexOf(tparam), tparam1)
-            } yield AnnotationZipper(ann, tparam1, ddef.copy(tparams = tparams1))
+            } yield AnnotationZipper(ann, tparam1, atPos(tree.pos)(ddef.copy(tparams = tparams1)))
             val vzippers = for {
               vparams <- vparamss
               vparam <- vparams
               AnnotationZipper(ann, vparam1: ValDef, _) <- loop(vparam, deep = false)
               vparams1 = vparams.updated(vparams.indexOf(vparam), vparam1)
               vparamss1 = vparamss.updated(vparamss.indexOf(vparams), vparams1)
-            } yield AnnotationZipper(ann, vparam1, ddef.copy(vparamss = vparamss1))
+            } yield AnnotationZipper(ann, vparam1, atPos(tree.pos)(ddef.copy(vparamss = vparamss1)))
             dzippers ++ tzippers ++ vzippers
           }
         case vdef @ ValDef(mods, _, _, _) =>
           mods.annotations.map(ann => {
-            val annottee = vdef.copy(mods = mods.mapAnnotations(_ diff List(ann)))
+            val annottee = atPos(tree.pos)(vdef.copy(mods = mods.mapAnnotations(_ diff List(ann))))
             AnnotationZipper(ann, annottee, annottee)
           })
         case tdef @ TypeDef(mods, _, tparams, _) =>
           val tzippers = mods.annotations.map(ann => {
-            val annottee = tdef.copy(mods = mods.mapAnnotations(_ diff List(ann)))
+            val annottee = atPos(tree.pos)(tdef.copy(mods = mods.mapAnnotations(_ diff List(ann))))
             AnnotationZipper(ann, annottee, annottee)
           })
           if (!deep) tzippers
@@ -108,7 +108,7 @@ trait TreeInfo {
               tparam <- tparams
               AnnotationZipper(ann, tparam1: TypeDef, _) <- loop(tparam, deep = false)
               tparams1 = tparams.updated(tparams.indexOf(tparam), tparam1)
-            } yield AnnotationZipper(ann, tparam1, tdef.copy(tparams = tparams1))
+            } yield AnnotationZipper(ann, tparam1, atPos(tree.pos)(tdef.copy(tparams = tparams1)))
             tzippers ++ ttzippers
           }
         case _ =>

--- a/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
+++ b/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
@@ -106,24 +106,25 @@ trait Expanders {
           val metaTargs = targs.map(toMeta)
           val metaVargss = vargss.map(_.map(toMeta))
           val metaExpandees = {
-            if (expandees.length != 1) sys.error("fatal error: multiple expandees not supported at the moment")
-            val metaOriginal = toMeta(original)
-            val metaOriginalWithoutAnnots = metaOriginal.transform {
-              // TODO: detect and remove just annotteeTree
-              case defn: scala.meta.Decl.Val => defn.copy(mods = filterMods(defn.mods))
-              case defn: scala.meta.Decl.Var => defn.copy(mods = filterMods(defn.mods))
-              case defn: scala.meta.Decl.Def => defn.copy(mods = filterMods(defn.mods))
-              case defn: scala.meta.Decl.Type => defn.copy(mods = filterMods(defn.mods))
-              case defn: scala.meta.Defn.Val => defn.copy(mods = filterMods(defn.mods))
-              case defn: scala.meta.Defn.Var => defn.copy(mods = filterMods(defn.mods))
-              case defn: scala.meta.Defn.Def => defn.copy(mods = filterMods(defn.mods))
-              case defn: scala.meta.Defn.Macro => defn.copy(mods = filterMods(defn.mods))
-              case defn: scala.meta.Defn.Type => defn.copy(mods = filterMods(defn.mods))
-              case defn: scala.meta.Defn.Class => defn.copy(mods = filterMods(defn.mods))
-              case defn: scala.meta.Defn.Trait => defn.copy(mods = filterMods(defn.mods))
-              case defn: scala.meta.Defn.Object => defn.copy(mods = filterMods(defn.mods))
+            expandees.flatMap { expandee =>
+              val metaExpandee = toMeta(expandee)
+              val metaExpandeeWithoutAnnots = metaExpandee.transform {
+                // TODO: detect and remove just annotteeTree
+                case defn: scala.meta.Decl.Val => defn.copy(mods = filterMods(defn.mods))
+                case defn: scala.meta.Decl.Var => defn.copy(mods = filterMods(defn.mods))
+                case defn: scala.meta.Decl.Def => defn.copy(mods = filterMods(defn.mods))
+                case defn: scala.meta.Decl.Type => defn.copy(mods = filterMods(defn.mods))
+                case defn: scala.meta.Defn.Val => defn.copy(mods = filterMods(defn.mods))
+                case defn: scala.meta.Defn.Var => defn.copy(mods = filterMods(defn.mods))
+                case defn: scala.meta.Defn.Def => defn.copy(mods = filterMods(defn.mods))
+                case defn: scala.meta.Defn.Macro => defn.copy(mods = filterMods(defn.mods))
+                case defn: scala.meta.Defn.Type => defn.copy(mods = filterMods(defn.mods))
+                case defn: scala.meta.Defn.Class => defn.copy(mods = filterMods(defn.mods))
+                case defn: scala.meta.Defn.Trait => defn.copy(mods = filterMods(defn.mods))
+                case defn: scala.meta.Defn.Object => defn.copy(mods = filterMods(defn.mods))
+              }
+              List(metaExpandeeWithoutAnnots)
             }
-            List(metaOriginalWithoutAnnots)
           }
           val metaArgs = metaTargs ++ metaVargss.flatten ++ metaExpandees
 

--- a/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
+++ b/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
@@ -124,11 +124,11 @@ trait Expanders {
               }
             }
           }
-          val metaArg = (metaTargs ++ metaVargss.flatten ++ metaExpandees) match {
-            case Nil => Nil
+          val metaArgs = metaTargs ++ metaVargss.flatten ++ List(metaExpandees match {
+            case Nil => throw MacroExpansionException
             case tree :: Nil => tree
             case list @ _ :: tail => scala.meta.Term.Block(list.asInstanceOf[Seq[scala.meta.Stat]])
-          }
+          })
 
           val classloader = {
             val m_findMacroClassLoader = analyzer.getClass.getMethods().find(_.getName == "findMacroClassLoader").get
@@ -149,7 +149,7 @@ trait Expanders {
           val metaExpansion = {
             // NOTE: this method is here for correct stacktrace unwrapping
             def macroExpandWithRuntime() = {
-              try newStyleMacroMeth.invoke(annotationModule, metaArg).asInstanceOf[MetaTree]
+              try newStyleMacroMeth.invoke(annotationModule, metaArgs.asInstanceOf[List[AnyRef]].toArray: _*).asInstanceOf[MetaTree]
               catch {
                 case ex: Throwable =>
                   val realex = ReflectionUtils.unwrapThrowable(ex)

--- a/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
+++ b/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
@@ -106,9 +106,8 @@ trait Expanders {
           val metaTargs = targs.map(toMeta)
           val metaVargss = vargss.map(_.map(toMeta))
           val metaExpandees = {
-            expandees.flatMap { expandee =>
-              val metaExpandee = toMeta(expandee)
-              val metaExpandeeWithoutAnnots = metaExpandee.transform {
+            expandees.map { expandee =>
+              toMeta(expandee).transform {
                 // TODO: detect and remove just annotteeTree
                 case defn: scala.meta.Decl.Val => defn.copy(mods = filterMods(defn.mods))
                 case defn: scala.meta.Decl.Var => defn.copy(mods = filterMods(defn.mods))
@@ -123,7 +122,6 @@ trait Expanders {
                 case defn: scala.meta.Defn.Trait => defn.copy(mods = filterMods(defn.mods))
                 case defn: scala.meta.Defn.Object => defn.copy(mods = filterMods(defn.mods))
               }
-              List(metaExpandeeWithoutAnnots)
             }
           }
           val metaArgs = metaTargs ++ metaVargss.flatten ++ metaExpandees

--- a/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
+++ b/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
@@ -124,7 +124,11 @@ trait Expanders {
               }
             }
           }
-          val metaArgs = metaTargs ++ metaVargss.flatten ++ metaExpandees
+          val metaArg = (metaTargs ++ metaVargss.flatten ++ metaExpandees) match {
+            case Nil => Nil
+            case tree :: Nil => tree
+            case list @ _ :: tail => scala.meta.Term.Block(list.asInstanceOf[Seq[scala.meta.Stat]])
+          }
 
           val classloader = {
             val m_findMacroClassLoader = analyzer.getClass.getMethods().find(_.getName == "findMacroClassLoader").get
@@ -145,7 +149,7 @@ trait Expanders {
           val metaExpansion = {
             // NOTE: this method is here for correct stacktrace unwrapping
             def macroExpandWithRuntime() = {
-              try newStyleMacroMeth.invoke(annotationModule, metaArgs.asInstanceOf[List[AnyRef]].toArray: _*).asInstanceOf[MetaTree]
+              try newStyleMacroMeth.invoke(annotationModule, metaArg).asInstanceOf[MetaTree]
               catch {
                 case ex: Throwable =>
                   val realex = ReflectionUtils.unwrapThrowable(ex)

--- a/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
+++ b/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Expanders.scala
@@ -125,7 +125,7 @@ trait Expanders {
             }
           }
           val metaArgs = metaTargs ++ metaVargss.flatten ++ List(metaExpandees match {
-            case Nil => throw MacroExpansionException
+            case Nil => abort("Something unexpected happened. Please report the maintainer.")
             case tree :: Nil => tree
             case list @ _ :: tail => scala.meta.Term.Block(list.asInstanceOf[Seq[scala.meta.Stat]])
           })

--- a/tests/src/main/scala/annotations/new/main/CompanionMacros.scala
+++ b/tests/src/main/scala/annotations/new/main/CompanionMacros.scala
@@ -1,0 +1,43 @@
+package main
+
+import scala.annotation.compileTimeOnly
+import scala.meta._
+
+@compileTimeOnly("@classMacro not expanded")
+class classMacro extends scala.annotation.StaticAnnotation {
+
+  inline def apply(classDefn: Defn.Class, companionDefn: Defn.Object): Stat = meta {
+    val classTree: Stat = {
+      val q"""
+        ..$mods class $tname[..$tparams] ..$ctorMods (...$paramss) extends { ..$earlyStats } with ..$ctorcalls {
+          $selfParam =>
+          ..$stats
+        }
+      """ = classDefn
+      q"""
+        ..$mods class $tname[..$tparams] ..$ctorMods (...$paramss) extends { ..$earlyStats } with ..$ctorcalls {
+          $selfParam =>
+          ..$stats
+        }
+      """
+    }
+
+    val companionTree: Stat = {
+      val q"""
+        ..$mods object $tname extends { ..$earlyStats } with ..$ctorcalls {
+          $selfParam =>
+          ..$stats
+        }
+      """ = companionDefn
+      q"""
+        ..$mods object $tname extends { ..$earlyStats } with ..$ctorcalls {
+          $selfParam =>
+          ..$stats
+        }
+      """
+    }
+
+    Term.Block(scala.collection.immutable.Seq(classTree, companionTree))
+  }
+
+}

--- a/tests/src/test/scala/annotations/new/main/Companion.scala
+++ b/tests/src/test/scala/annotations/new/main/Companion.scala
@@ -11,3 +11,7 @@ trait Bar {
 object Foo extends Bar {
   val j: Int = 2
 }
+
+@classMacro class Baz(id: Int) {
+  val a: String = "abc"
+}

--- a/tests/src/test/scala/annotations/new/main/Companion.scala
+++ b/tests/src/test/scala/annotations/new/main/Companion.scala
@@ -1,0 +1,13 @@
+package main
+
+trait Bar {
+  val k: Int = 3
+}
+
+@classMacro class Foo(id: Int) {
+  val i: Int = 1
+}
+
+object Foo extends Bar {
+  val j: Int = 2
+}


### PR DESCRIPTION
Fix `multiple expandees` error.
See #12 for the circumstances and discussions.

Notes for review:
* At first I tried to expand each `expandee` using `toMeta()`, but that attempt resulted in `java.lang.UnsupportedOperationException: Position.point on NoPosition`.
* This was because the `expandee`, which was generated in `TreeInfo.getAnnotationZippers()`, did not have an appropriate `pos: Position` (actually it was `NoPosition`), therefore I seeked a method for add the one to the `expandee`.
* I used `atPos()` method of `Positions` trait, but did it ok?
* If It is ok, please confirm followings:
  * whether I changed EVERY necessary lines in `getAnnotationZippers()` with `atPos()`
  * I used `tree.pos` as the position of annottee, but is this right?
* And if not, please give me some pointers to alternatives.