### PR TITLE
Add support for multiple expansion

### DIFF
--- a/tests/src/main/scala/annotations/new/main/Defs.scala
+++ b/tests/src/main/scala/annotations/new/main/Defs.scala
@@ -1,6 +1,7 @@
 package main
 
 import scala.annotation.compileTimeOnly
+import scala.meta.Term.Block
 import scala.meta._
 
 @compileTimeOnly("@printDef not expanded")
@@ -33,4 +34,58 @@ class identity extends scala.annotation.StaticAnnotation {
   inline def apply(defn: Defn) = meta {
     defn
   }
+}
+
+@compileTimeOnly("@populateDef not expanded")
+class helloWorld extends scala.annotation.StaticAnnotation {
+  inline def apply(defn: Defn.Def) = meta {
+    val q"..$mods def $name[..$tparams](...$paramss): $tpeopt = $expr" = defn
+    q"""..$mods def $name[..$tparams](...$paramss): $tpeopt = "hello world""""
+  }
+}
+
+@compileTimeOnly("@appendA not expanded")
+class appendA extends scala.annotation.StaticAnnotation {
+  inline def apply(defn: Defn.Def) = meta {
+    val q"..$mods def $name[..$tparams](...$paramss): $tpeopt = $expr" = defn
+    val stat = q"letters += 'a'"
+    val newExpr = expr match {
+      case b:Block => b.copy(stats = b.stats :+ stat)
+      case t:Term => val stats = Vector(stat, t)
+        q"{ ..$stats }"
+    }
+    q"..$mods def $name[..$tparams](...$paramss): $tpeopt = $newExpr"
+  }
+}
+
+@compileTimeOnly("@appendB not expanded")
+class appendB extends scala.annotation.StaticAnnotation {
+  inline def apply(defn: Defn.Def) = meta {
+    val q"..$mods def $name[..$tparams](...$paramss): $tpeopt = $expr" = defn
+    val stat = q"letters += 'b'"
+    val newExpr = expr match {
+      case b:Block => b.copy(stats = b.stats :+ stat)
+      case t:Term => val stats = Vector(stat, t)
+        q"{ ..$stats }"
+    }
+    q"..$mods def $name[..$tparams](...$paramss): $tpeopt = $newExpr"
+  }
+}
+
+@compileTimeOnly("@appendC not expanded")
+class appendC extends scala.annotation.StaticAnnotation {
+  inline def apply(defn: Defn.Def) = meta {
+    val q"..$mods def $name[..$tparams](...$paramss): $tpeopt = $expr" = defn
+    val stat = q"letters += 'c'"
+    val newExpr = expr match {
+      case b:Block => b.copy(stats = b.stats :+ stat)
+      case t:Term => val stats = Vector(stat, t)
+        q"{ ..$stats }"
+    }
+    q"..$mods def $name[..$tparams](...$paramss): $tpeopt = $newExpr"
+  }
+}
+
+package placebo {
+  class appendA extends scala.annotation.StaticAnnotation
 }

--- a/tests/src/test/scala/annotations/new/main/ExpansionTests.scala
+++ b/tests/src/test/scala/annotations/new/main/ExpansionTests.scala
@@ -1,0 +1,183 @@
+import main._
+import org.scalatest.FunSuite
+
+// TODO: DavidDudson: simplify with argument macros
+class ExpansionTests extends FunSuite {
+
+  test("Nested macro should expand with identity") {
+    @identity
+    object Foo {
+      @helloWorld def bar() = "test"
+    }
+
+    assert(Foo.bar() === "hello world")
+  }
+
+  test("Nested macro of the same name should expand") {
+    var letters = ""
+
+    @appendA
+    def foo() = {
+      @appendA
+      def bar() = {}
+      bar()
+    }
+
+    foo()
+
+    assert(letters === "aa")
+  }
+
+  test("Nested macro should expand with different macros") {
+    var letters = ""
+
+    @appendA
+    def foo() = {
+      @appendB
+      def bar() = {}
+      bar()
+    }
+
+    foo()
+
+    assert(letters === "ba")
+  }
+
+  // Provided the above test passes... This proves that
+  // Macros expansion order:
+  // Left -> Right
+  // In -> Out
+  test("Verify expansion order") {
+    var letters = ""
+
+    @appendB @appendC
+    def foo() = {
+      @appendA
+      def bar() = {}
+      bar()
+    }
+
+    foo()
+
+    assert(letters === "abc")
+  }
+
+  test("Nested macro should expand with inner identity macro") {
+    var letters = ""
+
+    @appendA
+    def foo() = {
+      @identity
+      def bar() = {}
+      bar()
+    }
+
+    foo()
+
+    assert(letters === "a")
+  }
+
+  test("Nested macro should expand with outer identity macro") {
+    var letters = ""
+
+    @identity
+    def foo() = {
+      @appendA
+      def bar() = {}
+      bar()
+    }
+
+    foo()
+
+    assert(letters === "a")
+  }
+
+  test("Placebo after expandee should compile and work") {
+    var letters = ""
+
+    @appendA @placebo
+    def bar() = {}
+
+    bar()
+
+    assert(letters === "a")
+  }
+
+  test("Placebo before expandee should compile and work") {
+    var letters = ""
+
+    @placebo @appendA
+    def bar() = {}
+
+    bar()
+
+    assert(letters === "a")
+  }
+
+  test("Multiple expandees of same kinds with others in between should expand") {
+    var letters = ""
+
+    @appendA @identity @appendB
+    def bar() = {}
+
+    bar()
+
+    assert(letters === "ab")
+  }
+
+ test("Multiple expandees of similar kinds should expand in the correct order") {
+   var letters = ""
+
+
+   @appendA @appendB
+    def bar() = {}
+
+    bar()
+
+    assert(letters === "ab")
+  }
+
+  test("Identity expandee followed by regular expandee should expand correctly") {
+    var letters = ""
+
+    @identity @appendA
+    def bar() = {}
+
+    bar()
+
+    assert(letters === "a")
+  }
+
+  test("Regular expandee followed by Identity expandee should expand correctly") {
+    var letters = ""
+
+    @appendA @identity
+    def bar() = {}
+
+    bar()
+
+    assert(letters === "a")
+  }
+
+  test("Placebo in package doesnt accidentally get removed if second") {
+    var letters = ""
+
+    @appendA @placebo.appendA
+    def bar() = {}
+
+    bar()
+
+    assert(letters === "a")
+  }
+
+  test("Placebo in package doesnt accidentally get removed if first") {
+    var letters = ""
+
+    @placebo.appendA @appendA
+    def bar() = {}
+
+    bar()
+
+    assert(letters === "a")
+  }
+}


### PR DESCRIPTION
This provides support for multiple expansion and nested expansion.
This fixes. https://github.com/scalameta/paradise/issues/18 and https://github.com/scalameta/paradise/issues/13.

Due to a lack of knowledge I have unfortunately been unable to implement the filter via scala's compiler mechanisms. So this is a fix from the users perspective, but will not cover all cases and needs be modified.

As @xeno-by suggested, we should be finding index of the annotation. and removing it that way.

From my investigation it seems like matching on scala.reflects trees or using positions does not give the desired results in order to shrink the filtering code. I probably just don't understand the compiler tools enough yet. If anyone could direct me in the right direction that would be good.

What I really would like to be able to do is simply 

```mods diff annotationTree.toMtree :: Nil```

But of course, it is not that simple.