### PR TITLE
Update ScalaTest to 3.0.0

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -162,7 +162,7 @@ object build extends Build {
     libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _),
     libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-compiler" % _),
     libraryDependencies += "org.scalameta" %% "scalameta" % MetaVersion,
-    libraryDependencies += "org.scalatest" % "scalatest_2.11.0-M3" % "1.9.1b" % "test",
+    libraryDependencies += "org.scalatest" % "scalatest_2.11" % "3.0.0" % "test",
     libraryDependencies += "org.scalacheck" % "scalacheck_2.11" % "1.10.2-SNAPSHOT" % "test",
     scalacOptions += "-Ywarn-unused-import",
     scalacOptions += "-Xfatal-warnings",

--- a/tests/src/test/scala/ReplSuite.scala
+++ b/tests/src/test/scala/ReplSuite.scala
@@ -1,3 +1,4 @@
+import org.scalactic.source.Position
 import org.scalatest._
 import scala.compat.Platform.EOL
 import scala.tools.nsc.interpreter._
@@ -64,7 +65,7 @@ trait ReplSuite extends ToolSuite {
   private var _repl: String => String = null
   final protected def repl(code: String): String = _repl(code)
 
-  override protected def test(testName: String, testTags: Tag*)(testFun: => Unit): Unit = {
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit pos: Position): Unit = {
     super.test(testName + " (ILoop)", testTags: _*)({ this._repl = replViaILoop _; testFun })
     super.test(testName + " (ReplGlobal)", testTags: _*)({ this._repl = replViaReplGlobal _; testFun })
   }


### PR DESCRIPTION
Why?
I've started to use the `compile` matcher to my personal repo's and figured it would be useful for paradise in the future.

This allows the syntax

`"@SomeAnnotation def foo() = 1" should compile`
`"@SomeAnnotation def foo() = 1" should typeCheck`

Depending on what is wanted we could have some pretty thorough tests.

Eg. 

```scala
val annotations = Seq("Identity", "Duplicate")
val defs = Seq("def hello() = 1", "private def hello() = 1",  "inline def hello() = 1")

for {
 a <- annonations,
 d <- def
} {
  a + d should compile
}
```
At some point in the future after the semantic api I would like to extend this with some sort of intuitive semantic testing framework.

Some possible not very thought out examples....

`"@Identity def foo() = 1" afterExpansion annotations shouldBe empty`
`"@Identity def foo() = 1" afterExpansion syntax shouldBe "def foo() = 1"`
`"@Identity def foo() = 1" afterExpansion structure shouldBe someStructure`
`"@Identity def foo() = 1" should expand`
