### PR TITLE
Disable scala.color in ReplSuite

### DIFF
--- a/tests/src/test/scala/DisableScalaColor.scala
+++ b/tests/src/test/scala/DisableScalaColor.scala
@@ -1,0 +1,17 @@
+import org.scalatest._
+
+/** Ensure that scala.color doesn't interact with the REPL output assertions. */
+trait DisableScalaColor extends BeforeAndAfterAll { this: Suite =>
+  var scalaColor: Option[String] = None
+
+  override protected def beforeAll() = {
+    scalaColor = sys.props get "scala.color"
+    if (scalaColor.isDefined) sys.props("scala.color") = "false"
+    super.beforeAll()
+  }
+
+  override protected def afterAll() = {
+    super.afterAll()
+    scalaColor foreach (s => sys.props("scala.color") = s)
+  }
+}

--- a/tests/src/test/scala/ReplSuite.scala
+++ b/tests/src/test/scala/ReplSuite.scala
@@ -4,7 +4,7 @@ import scala.compat.Platform.EOL
 import scala.tools.nsc.interpreter._
 import scala.tools.nsc.{Settings, MainGenericRunner}
 
-trait ReplSuite extends ToolSuite {
+trait ReplSuite extends ToolSuite with DisableScalaColor {
   private def replViaILoop(code: String): String = {
     val s = new Settings
     s.Xnojline.value = true


### PR DESCRIPTION
I have a ~/.sbt/0.13/colour.sbt file:

    initialize ~= (_ => if (ConsoleLogger.formatEnabled) sys.props("scala.color") = "true")

which was interacting with paradise's REPL tests.

With this change the issue is fixed.

Fixes #38