### PR TITLE
fix toMtree to covert Term.Arg.Named properly

### DIFF
--- a/plugin/src/main/scala/org/scalamacros/paradise/converters/ToMtree.scala
+++ b/plugin/src/main/scala/org/scalamacros/paradise/converters/ToMtree.scala
@@ -61,7 +61,7 @@ trait ToMtree extends Enrichments
 
               case l.TermApply(lfun, largs) if !termSelectContainsConstructor(lfun) =>
                 val mfun = lfun.toMtree[m.Term]
-                val margs = largs.toMtrees[m.Term]
+                val margs = largs.toMtrees[m.Term.Arg]
                 m.Term.Apply(mfun, margs)
 
               case l.TermApplyType(lfun, ltargs) =>

--- a/tests/src/test/scala/annotations/new/main/TestMods.scala
+++ b/tests/src/test/scala/annotations/new/main/TestMods.scala
@@ -26,3 +26,8 @@ case class Test4()
   println(Test4().productPrefix)
   println(Test5.toString)
 }
+
+@identity object NamedArg {
+  case class MyCaseClass(a: Int, b: Int)
+  MyCaseClass(0, 1).copy(2, b = 3)
+}


### PR DESCRIPTION
#40 fails when converting named arguments to `Mtree` (sample code and stacktrace below).
This is because `Term.Arg.Named` is unassignable to `Term` (https://github.com/scalameta/paradise/blob/f0e89df9ce23c223529f868c9440f5bee036f0bb/plugin/src/main/scala/org/scalamacros/paradise/converters/ToMtree.scala#L385).
However, both `Term.Arg.Named` and `Term` expand `Term.Arg`

code
```scala
@identity object NamedArg {
  case class MyCaseClass(a: Int, b: Int)
  MyCaseClass(0, 1).copy(b = 2)
}
```

stacktrace
```
org.scalameta.paradise.converters.ConvertException: unexpected result: expected = Term, actual = Term.Arg.Named
AssignOrNamedArg(Ident(TermName("b")), Literal(Constant(2)))
Term.Arg.Named(Term.Name("b"), Lit(2))
(AssignOrNamedArg) b = 2
(Apply) MyCaseClass(0, 1).copy(b = 2)
(Template) Template(List(), List(), val _ = _, Some(List(case class MyCaseClass extends scala.Product with scala.Serializable {
  <caseaccessor> <paramaccessor> val a: Int = _;
  <caseaccessor> <paramaccessor> val b: Int = _;
  def <init>(a: Int, b: Int) = {
    super.<init>();
    ()
  }
}, MyCaseClass(0, 1).copy(b = 2))))
(ModuleDef) object NamedArg extends scala.AnyRef {
  def <init>() = {
    super.<init>();
    ()
  };
  case class MyCaseClass extends scala.Product with scala.Serializable {
    <caseaccessor> <paramaccessor> val a: Int = _;
    <caseaccessor> <paramaccessor> val b: Int = _;
    def <init>(a: Int, b: Int) = {
      super.<init>();
      ()
    }
  };
  MyCaseClass(0, 1).copy(b = 2)
}
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$.fail(ToMtree.scala:421)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$.wrap(ToMtree.scala:396)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$XtensionGtreeToMtree.toMtree(ToMtree.scala:35)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$RichTreesToMtrees$$anonfun$toMtrees$1.apply(ToMtree.scala:370)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$RichTreesToMtrees$$anonfun$toMtrees$1.apply(ToMtree.scala:370)
	at scala.collection.immutable.List.map(List.scala:273)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$RichTreesToMtrees.toMtrees(ToMtree.scala:370)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$XtensionGtreeToMtree$$anonfun$toMtree$1.apply(ToMtree.scala:64)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$XtensionGtreeToMtree$$anonfun$toMtree$1.apply(ToMtree.scala:35)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$.wrap(ToMtree.scala:383)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$XtensionGtreeToMtree.toMtree(ToMtree.scala:35)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$RichTreesToMtrees$$anonfun$toMtrees$1.apply(ToMtree.scala:370)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$RichTreesToMtrees$$anonfun$toMtrees$1.apply(ToMtree.scala:370)
	at scala.collection.immutable.List.map(List.scala:277)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$RichTreesToMtrees.toMtrees(ToMtree.scala:370)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$XtensionGtreeToMtree$$anonfun$toMtree$1$$anonfun$1.apply(ToMtree.scala:272)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$XtensionGtreeToMtree$$anonfun$toMtree$1$$anonfun$1.apply(ToMtree.scala:272)
	at scala.Option.map(Option.scala:146)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$XtensionGtreeToMtree$$anonfun$toMtree$1.apply(ToMtree.scala:272)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$XtensionGtreeToMtree$$anonfun$toMtree$1.apply(ToMtree.scala:35)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$.wrap(ToMtree.scala:383)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$XtensionGtreeToMtree.toMtree(ToMtree.scala:35)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$XtensionGtreeToMtree$$anonfun$toMtree$1.apply(ToMtree.scala:241)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$XtensionGtreeToMtree$$anonfun$toMtree$1.apply(ToMtree.scala:35)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$.wrap(ToMtree.scala:383)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$XtensionGtreeToMtree.toMtree(ToMtree.scala:35)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$$anonfun$5.apply(ToMtree.scala:434)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$$anonfun$5.apply(ToMtree.scala:425)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$.wrap(ToMtree.scala:383)
	at org.scalameta.paradise.converters.ToMtree$toMtree$2$.apply(ToMtree.scala:425)
	at org.scalameta.paradise.converters.ToMtree$class.org$scalameta$paradise$converters$ToMtree$$toMtree(ToMtree.scala:440)
	at org.scalameta.paradise.converters.ToMtree$XtensionGtreeToMtree.toMtree(ToMtree.scala:28)
	at org.scalameta.paradise.typechecker.Expanders$Expander$$anonfun$1.apply(Expanders.scala:78)
	at org.scalameta.paradise.typechecker.Expanders$Expander$$anonfun$1.apply(Expanders.scala:78)
	at scala.collection.immutable.List.map(List.scala:273)
	at org.scalameta.paradise.typechecker.Expanders$Expander$class.expand$2(Expanders.scala:78)
	at org.scalameta.paradise.typechecker.Expanders$Expander$$anonfun$expandNewAnnotationMacro$1.apply(Expanders.scala:142)
	at org.scalameta.paradise.typechecker.Expanders$Expander$$anonfun$expandNewAnnotationMacro$1.apply(Expanders.scala:142)
	at org.scalameta.paradise.typechecker.Expanders$Expander$class.extractAndValidateExpansions(Expanders.scala:207)
	at org.scalameta.paradise.typechecker.Expanders$Expander$class.expandNewAnnotationMacro(Expanders.scala:142)
	at org.scalameta.paradise.typechecker.Namers$$anon$3.expandNewAnnotationMacro(Namers.scala:13)
	at org.scalameta.paradise.typechecker.Namers$Namer$$anon$2.org$scalameta$paradise$typechecker$Namers$Namer$class$$anon$$maybeExpand$1(Namers.scala:370)
	at org.scalameta.paradise.typechecker.Namers$Namer$$anon$2$$anonfun$7.apply(Namers.scala:377)
	at org.scalameta.paradise.typechecker.Namers$Namer$$anon$2$$anonfun$7.apply(Namers.scala:377)
	at scala.collection.immutable.Stream.flatMap(Stream.scala:489)
	at org.scalameta.paradise.typechecker.Namers$Namer$$anon$2.maybeExpand(Namers.scala:377)
	at org.scalameta.paradise.typechecker.Namers$Namer$MaybeExpandeeCompleter.completeImpl(Namers.scala:322)
	at org.scalameta.paradise.typechecker.Namers$Namer$MaybeExpandeeCompleter.complete(Namers.scala:312)
	at org.scalameta.paradise.typechecker.Namers$Namer$RichType.completeOnlyExpansions(Namers.scala:340)
	at org.scalameta.paradise.typechecker.Expanders$Expander$$anonfun$expandMacroAnnotations$2.apply(Expanders.scala:234)
	at org.scalameta.paradise.typechecker.Expanders$Expander$$anonfun$expandMacroAnnotations$2.apply(Expanders.scala:227)
	at scala.collection.immutable.List.flatMap(List.scala:327)
	at org.scalameta.paradise.typechecker.Expanders$Expander$class.expandMacroAnnotations(Expanders.scala:227)
	at org.scalameta.paradise.typechecker.Expanders$$anon$1.expandMacroAnnotations(Expanders.scala:22)
	at org.scalameta.paradise.typechecker.AnalyzerPlugins$MacroPlugin$.pluginsEnterStats(AnalyzerPlugins.scala:41)
	at scala.tools.nsc.typechecker.AnalyzerPlugins$$anonfun$pluginsEnterStats$1.apply(AnalyzerPlugins.scala:450)
	at scala.tools.nsc.typechecker.AnalyzerPlugins$$anonfun$pluginsEnterStats$1.apply(AnalyzerPlugins.scala:449)
	at scala.collection.LinearSeqOptimized$class.foldLeft(LinearSeqOptimized.scala:124)
	at scala.collection.immutable.List.foldLeft(List.scala:84)
	at scala.tools.nsc.typechecker.AnalyzerPlugins$class.pluginsEnterStats(AnalyzerPlugins.scala:449)
	at org.scalameta.paradise.typechecker.HijackAnalyzer$$anon$2.pluginsEnterStats(HijackAnalyzer.scala:28)
	at scala.tools.nsc.typechecker.Typers$Typer.typedPackageDef$1(Typers.scala:5011)
	at scala.tools.nsc.typechecker.Typers$Typer.typedMemberDef$1(Typers.scala:5312)
	at scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5359)
	at scala.tools.nsc.typechecker.Typers$Typer.runTyper$1(Typers.scala:5396)
	at scala.tools.nsc.typechecker.Typers$Typer.scala$tools$nsc$typechecker$Typers$Typer$$typedInternal(Typers.scala:5423)
	at scala.tools.nsc.typechecker.Typers$Typer.body$2(Typers.scala:5370)
	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5374)
	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5448)
	at scala.tools.nsc.typechecker.Analyzer$typerFactory$$anon$3.apply(Analyzer.scala:102)
	at scala.tools.nsc.Global$GlobalPhase$$anonfun$applyPhase$1.apply$mcV$sp(Global.scala:440)
	at scala.tools.nsc.Global$GlobalPhase.withCurrentUnit(Global.scala:431)
	at scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:440)
	at scala.tools.nsc.typechecker.Analyzer$typerFactory$$anon$3$$anonfun$run$1.apply(Analyzer.scala:94)
	at scala.tools.nsc.typechecker.Analyzer$typerFactory$$anon$3$$anonfun$run$1.apply(Analyzer.scala:93)
	at scala.collection.Iterator$class.foreach(Iterator.scala:893)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	at scala.tools.nsc.typechecker.Analyzer$typerFactory$$anon$3.run(Analyzer.scala:93)
	at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1501)
	at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1486)
	at scala.tools.nsc.Global$Run.compileSources(Global.scala:1481)
	at scala.tools.nsc.Global$Run.compile(Global.scala:1582)
	at xsbt.CachedCompiler0.run(CompilerInterface.scala:123)
	at xsbt.CachedCompiler0.run(CompilerInterface.scala:99)
	at xsbt.CompilerInterface.run(CompilerInterface.scala:27)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sbt.compiler.AnalyzingCompiler.call(AnalyzingCompiler.scala:102)
	at sbt.compiler.AnalyzingCompiler.compile(AnalyzingCompiler.scala:48)
	at sbt.compiler.AnalyzingCompiler.compile(AnalyzingCompiler.scala:41)
	at sbt.compiler.AggressiveCompile$$anonfun$3$$anonfun$compileScala$1$1.apply$mcV$sp(AggressiveCompile.scala:99)
	at sbt.compiler.AggressiveCompile$$anonfun$3$$anonfun$compileScala$1$1.apply(AggressiveCompile.scala:99)
	at sbt.compiler.AggressiveCompile$$anonfun$3$$anonfun$compileScala$1$1.apply(AggressiveCompile.scala:99)
	at sbt.compiler.AggressiveCompile.sbt$compiler$AggressiveCompile$$timed(AggressiveCompile.scala:166)
	at sbt.compiler.AggressiveCompile$$anonfun$3.compileScala$1(AggressiveCompile.scala:98)
	at sbt.compiler.AggressiveCompile$$anonfun$3.apply(AggressiveCompile.scala:143)
	at sbt.compiler.AggressiveCompile$$anonfun$3.apply(AggressiveCompile.scala:87)
	at sbt.inc.IncrementalCompile$$anonfun$doCompile$1.apply(Compile.scala:39)
	at sbt.inc.IncrementalCompile$$anonfun$doCompile$1.apply(Compile.scala:37)
	at sbt.inc.IncrementalCommon.cycle(Incremental.scala:99)
	at sbt.inc.Incremental$$anonfun$1.apply(Incremental.scala:38)
	at sbt.inc.Incremental$$anonfun$1.apply(Incremental.scala:37)
	at sbt.inc.Incremental$.manageClassfiles(Incremental.scala:65)
	at sbt.inc.Incremental$.compile(Incremental.scala:37)
	at sbt.inc.IncrementalCompile$.apply(Compile.scala:27)
	at sbt.compiler.AggressiveCompile.compile2(AggressiveCompile.scala:157)
	at sbt.compiler.AggressiveCompile.compile1(AggressiveCompile.scala:71)
	at sbt.compiler.AggressiveCompile.apply(AggressiveCompile.scala:46)
	at sbt.Compiler$.apply(Compiler.scala:75)
	at sbt.Compiler$.apply(Compiler.scala:66)
	at sbt.Defaults$.sbt$Defaults$$compileTaskImpl(Defaults.scala:770)
	at sbt.Defaults$$anonfun$compileTask$1.apply(Defaults.scala:762)
	at sbt.Defaults$$anonfun$compileTask$1.apply(Defaults.scala:762)
	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:42)
	at sbt.std.Transform$$anon$4.work(System.scala:64)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:237)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:18)
	at sbt.Execute.work(Execute.scala:244)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:237)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:160)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:30)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```