### PR TITLE
fix implicit params

### DIFF
--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/LogicalTrees.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/LogicalTrees.scala
@@ -898,14 +898,7 @@ trait LogicalTrees {
     }
 
     private def removeBounds(paramss: List[List[g.ValDef]]): List[List[g.ValDef]] = {
-      if (paramss.isEmpty) return Nil
-      val init :+ last = paramss
-      val hasImplicits = last.exists(_.mods.hasFlag(IMPLICIT))
-      val explicitss = if (hasImplicits) init else init :+ last
-      val implicits = if (hasImplicits) last else Nil
-      val limplicits = implicits.filter(_.name.startsWith(nme.EVIDENCE_PARAM_PREFIX))
-      val lparamss = if (limplicits.nonEmpty) explicitss :+ limplicits else explicitss
-      lparamss.map(_.map(_.set(TermParamRole)))
+      paramss.map(_.map(_.set(TermParamRole)))
     }
 
     private def toplevelStats(stats: List[g.Tree]): List[g.Tree] = {

--- a/tests/src/test/scala/annotations/new/main/TestMods.scala
+++ b/tests/src/test/scala/annotations/new/main/TestMods.scala
@@ -38,3 +38,7 @@ case class Test4()
     case (2 | 3 | 4 | 5) => false
   }
 }
+
+@identity object ImplicitArg {
+  def add(a: Int, b: Int, c: Int)(implicit z: Int = 0) = a + z
+}


### PR DESCRIPTION
Currently this plugin fails with a function which has curried implicit parameters (ignoring them)

```scala
// src
@identity def add(a: Int)(implicit z: Int): Int = a + z
// is converted to
def add(a: Int): Int = a.+(z) // crash!! z is undefined
```

This is because `LogicalTree` filters out implicit parameters which does not have certain prefix (`nme.EVIDENCE_PARAM_PREFIX'), and I'm not sure why such filter is necessary.
Therefore this PR suggests to remove this filter, but if it is necessary, could you explain why?

CC @xeno-by and @Dveim