### PR TITLE
ToMtreeSpec

### DIFF
--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/LogicalTrees.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/LogicalTrees.scala
@@ -100,7 +100,7 @@ trait LogicalTrees {
     }
     def displayName = {
       // NOTE: "<empty>", the internal name for empty package, isn't a valid Scala identifier, so we hack around
-      if (name == null || name == rootMirror.EmptyPackage.name || name == rootMirror.EmptyPackageClass.name) "_empty_"
+      if (name == null || name == nme.EMPTY_PACKAGE_NAME || name == tpnme.EMPTY_PACKAGE_NAME) "_empty_"
       // TODO: why did we need this in the past?
       // else if (name.isAnonymous) "_"
       else name.decodedName.toString

--- a/project/build.scala
+++ b/project/build.scala
@@ -185,5 +185,7 @@ object build extends Build {
     scalacOptions ++= Seq()
     // scalacOptions ++= Seq("-Xprint:typer")
     // scalacOptions ++= Seq("-Xlog-implicits")
+  ) dependsOn (
+    plugin
   )
 }

--- a/tests/src/test/scala/ToMtreeSpec.scala
+++ b/tests/src/test/scala/ToMtreeSpec.scala
@@ -1,0 +1,107 @@
+import org.scalameta.paradise.converters.Converter
+import org.scalatest._
+import scala.{meta => m}
+import scala.tools.nsc.{Global, Settings}
+import scala.tools.nsc.reporters.ConsoleReporter
+
+
+class ToMtreeSpec extends FlatSpec with Matchers {
+
+  val g = {
+    val settings = new Settings((str: String) => Unit)
+    val reporter = new ConsoleReporter(settings)
+    new Global(settings, reporter)
+  }
+
+  object ToMtreeAdapter extends { val global = g } with Converter {
+    def apply(gtree: Any): m.Stat = gtree.asInstanceOf[g.Tree].toMtree[m.Stat]
+  }
+
+  object MParser {
+    import scala.meta._
+    def apply(code: String): m.Tree = code.parse[m.Stat].get
+  }
+
+  object GParser {
+    import scala.reflect.runtime.universe._
+    import scala.tools.reflect.ToolBox
+    val tb = runtimeMirror(getClass.getClassLoader).mkToolBox()
+    def apply(code: String): g.Tree = tb.parse(code).asInstanceOf[g.Tree]
+  }
+
+  def test(className: String, code: String): Unit = {
+    it should s"convert $className" in {
+      val mtree = MParser(code)
+      val gtree = GParser(code)
+      val converted = ToMtreeAdapter(gtree)
+      println(mtree.structure)
+      println(converted.structure)
+      converted.structure shouldEqual mtree.structure
+    }
+  }
+
+  // ============ NAMES ============
+
+  // TODO
+
+  // ============ TERMS ============
+
+  //test("Term.This",                      "this") // XXX fails
+  test("Term.Name",                      "foo")
+  test("Term.Select",                    "foo.bar")
+  test("Term.Apply",                     "foo(bar)")
+  test("Term.ApplyType",                 "foo[T]")
+  test("Term.Assign",                    "foo = bar")
+  //test("Term.Block with single expr",    "{ foo }") // XXX fails
+  test("Term.Block with multiple exprs", "{ foo; bar }")
+  test("Term.If",                        "if (foo) bar")
+  test("Term.If with else",              "if (foo) bar else baz")
+  //test("Term.Match",                     "foo match { case bar => baz }") // XXX fails
+  test("Term.Function",                  "(foo: Int) => bar")
+  test("Term.While",                     "while (foo) bar")
+  //test("Term.New",                       "new Foo()") // XXX fails
+  test("Term.Arg.Named",                 "foo(bar = baz)")
+  //test("Term.Arg.Repeatd",               "foo(bar: _*)") // XXX fails
+  test("Term.Arg.Param",                 "def foo(bar: Int = baz) = qux")
+
+  // ============ TYPES ============
+
+  // TODO
+
+  // ============ PATTERNS ============
+
+  // TODO
+
+  // ============ LITERALS ============
+
+  // TODO
+
+  // ============ DECLS ============
+
+  // TODO
+
+  // ============ DEFNS ============
+
+  // TODO
+
+  // ============ PKGS ============
+
+  // TODO
+
+  // ============ CTORS ============
+
+  // TODO
+
+  // ============ TEMPLATES ============
+
+  // TODO
+
+  // ============ MODIFIERS ============
+
+  // TODO
+
+  // ============ ODDS & ENDS ============
+
+  // TODO
+
+}


### PR DESCRIPTION
This is a simple test interface for `ToMtree` module, based on discussion in #43.
As an example, I also added test cases for conversions (only for those related to `meta.Term`) which already exist in this repository.

Notes for review:
* In `paradise.reflect.LogicalTrees`, the hack for `<empty>` causes an error when the module is used in `test`. I replace it with equivalent (and primitive) expression.
* There are some failing tests (commented-out lines in `ToMtreeSpec`). Should they be solved in this PR?