### PR TITLE
Reformat everything with scalafmt.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,10 @@
 build:
   image: olafurpg/scalafix:0.0.1
   commands:
-    - sbt test
+    - ./bin/scalafmt --version 0.4.5 --test
+    - sbt clean test
+cache:
+  mount:
+    - $HOME/.scalafmt-bin
+    - $HOME/.ivy2
+    - $HOME/.coursier

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,8 @@
+style = defaultWithAlign
+maxColumn = 100
+optIn.breakChainOnFirstMethodDot = true
+project.git = true
+project.excludeFilters = [
+  plugin/src/main/scala/org/scalameta/paradise/backend/Backend.scala
+]
+runner.dialect = Paradise211

--- a/bin/scalafmt
+++ b/bin/scalafmt
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+check_binary(){
+  command -v "$0" >/dev/null 2>&1 || { echo >&2 "Missing dependency $0, exiting."; exit 1; }
+}
+
+# I'm not sure if this would have portability issues...
+check_version(){
+  if [[ $1 = $2 ]]; then
+    echo $1;
+  else
+    echo -e "$1\n$2" | sort -nr | head -1
+  fi
+}
+
+CURL=$(which curl)
+TAR=$(which tar)
+JAVA=$(which java)
+GREP=$(which grep)
+
+check_binary "$CURL"
+check_binary "$TAR"
+check_binary "$JAVA"
+check_binary "$GREP"
+
+check_latest () {
+  echo "Checking latest version from github..."
+  latest_version=$($CURL -s https://api.github.com/repos/olafurpg/scalafmt/releases/latest | $GREP -Eo '"tag_name":(.*)' | $GREP -Eo 'v[0-9\.]+')
+  if [[ $latest_version = "" ]]; then
+    echo "The github call failed, either because of an internet connection issue or rate limits..."
+    exit 1
+  fi
+}
+
+current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+version_file="$HOME/.scalafmt-bin/version"
+upgrade=false
+
+if [[ -e $version_file ]]; then
+  latest_version=$(cat $version_file)
+  scalafmt_version=$latest_version
+fi
+
+print_usage (){
+  echo -e "scalafmt runner verson: 0.1"
+  echo -e "Usage: ./scalafmt [RUNNER OPTS] [SCALAFMT OPTS]"
+  echo -e "--version [VERSION] \t Version to invoke for scalafmt (fmt: 0.4.2, not v0.4.2)"
+  echo -e "--dir [DIR] \t\t Directory to store scalafmt jars, default is $HOME/.scalafmt-bin/"
+  echo -e "--upgrade \t\t Check GitHub for the latest version of scalafmt and use that"
+  echo -e "--h \t\t\t Display this message, this must be the first arguement for this to be invoked"
+  echo
+  echo -e "This script only checks the first three args for it's options, anything beyond that is ignored"
+  echo -e "and will probably cause scalafmt to produce an error since these are not options in scalafmt's runtime"
+  exit 0;
+}
+
+# We check all 3 now because it's possible to pass upgrade in and then
+# pass a custom directory in. You can't pass all the args in, you have to choose
+# specifying a version or upgrading to the latest from github.
+if [[ "$1" = "--h" ]]; then
+  print_usage
+fi
+for arg in "$1" "$2" "$3"; do
+	case "$arg" in
+		--version)
+      if [[ $upgrade = true || $3 = "--upgrade" ]]; then
+        echo "You can't specify a custom version with --upgrade"
+        exit 1
+      fi
+		  if [[ $2 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        scalafmt_version="v$2"
+        echo "Using version: $scalafmt_version"
+		    shift 2
+		  else
+		    echo "You must pass a valid version with --v"
+		    exit 1
+		  fi
+		  ;;
+		--dir)
+			echo "Using dir: $2"
+			default_dir="$2"
+			shift 2
+			;;
+    --upgrade)
+      if [[ $2 = "--version" ]]; then
+        echo "You can't specify a custom version with --upgrade"
+        exit 1
+      fi
+      upgrade=true
+      check_latest
+      scalafmt_version=$latest_version
+      shift
+      ;;
+		*)
+		  ;;
+	esac
+done
+
+if [[ ! -e $version_file && $upgrade = false ]]; then
+  echo "No version file, checking for latest..."
+  check_latest
+  echo "Setting latest version to: $latest_version"
+  scalafmt_version=$latest_version
+fi
+
+if [[ ! "$default_dir" ]]; then
+  default_dir="$HOME/.scalafmt-bin/releases/$scalafmt_version"
+fi
+
+if [[ ! -d "$default_dir" ]]; then
+  echo "$default_dir does not exist, creating it..."
+  mkdir -p "$default_dir"
+fi
+
+echo $(check_version "$scalafmt_version" "$latest_version") > $version_file
+
+scala_version="2.11"
+scalafmt_filename="scalafmt-$scalafmt_version.jar"
+scalafmt_repo="https://github.com/olafurpg/scalafmt/releases/download/$scalafmt_version/scalafmt.tar.gz"
+
+set -e
+
+if [[ ! -e "$default_dir/scalafmt-$scalafmt_version.jar" ]]; then
+  echo "No scalafmt jar for version $scalafmt_version, downloading it..."
+  echo "From: $scalafmt_repo"
+  $CURL --progress -L "$scalafmt_repo" -o "$default_dir/scalafmt.tar.gz"
+  $TAR -xzf "$default_dir/scalafmt.tar.gz" -O "cli/target/scala-$scala_version/scalafmt.jar" > "$default_dir/$scalafmt_filename"
+  rm "$default_dir/scalafmt.tar.gz"
+fi
+
+$JAVA -jar "$default_dir/$scalafmt_filename" "$@"

--- a/plugin/src/main/scala/org/scalameta/paradise/Plugin.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/Plugin.scala
@@ -9,13 +9,14 @@ import org.scalameta.paradise.parser.HijackSyntaxAnalyzer
 import org.scalameta.paradise.typechecker.HijackAnalyzer
 import org.scalameta.paradise.typechecker.AnalyzerPlugins
 
-class Plugin(val global: Global) extends NscPlugin
-                                    with HijackSyntaxAnalyzer
-                                    with HijackAnalyzer
-                                    with AnalyzerPlugins {
-  val name = "macroparadise"
+class Plugin(val global: Global)
+    extends NscPlugin
+    with HijackSyntaxAnalyzer
+    with HijackAnalyzer
+    with AnalyzerPlugins {
+  val name        = "macroparadise"
   val description = "Empowers production Scala compiler with latest macro developments"
-  val components = Nil
+  val components  = Nil
 
   hijackSyntaxAnalyzer()
   val newAnalyzer = hijackAnalyzer()

--- a/plugin/src/main/scala/org/scalameta/paradise/Settings.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/Settings.scala
@@ -2,7 +2,7 @@ package org.scalameta.paradise
 
 object Settings {
   class Setting[T](get: () => T, set: T => Unit) {
-    def value = get()
+    def value             = get()
     def value_=(value: T) = set(value)
   }
 

--- a/plugin/src/main/scala/org/scalameta/paradise/backend/HijackBackend.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/backend/HijackBackend.scala
@@ -1,0 +1,45 @@
+package org.scalameta.paradise
+package backend
+
+import scala.collection.mutable
+import scala.tools.nsc.{Global, SubComponent}
+import scala.tools.nsc.plugins.{Plugin => NscPlugin}
+import scala.tools.nsc.backend.jvm.{GenBCode => NscGenBCode}
+
+trait HijackBackend { self: NscPlugin =>
+
+  // NOTE: mostly copy/pasted from https://github.com/VladimirNik/tasty/blob/7b45111d066ddbc43d859c9f6c0a81978111cf90/plugin/src/main/scala/scala/tasty/internal/scalac/Plugin.scala
+  // TODO: some hopes for making this hijacking unnecessary: https://groups.google.com/forum/#!topic/scala-internals/VYAi-9_qf80
+  def hijackBackend(): (global.genBCode.type, NscGenBCode) = {
+    if (sys.props("persist.enable") != null && self.global.settings.Ybackend.value == "GenBCode") {
+      val oldBackend = global.genBCode
+      object newBackend extends {
+        override val global: self.global.type = self.global
+      } with ParadiseGenBCode(global)
+
+      val genBCodeField = classOf[Global].getDeclaredField("genBCode$module")
+      genBCodeField.setAccessible(true)
+      genBCodeField.set(global, newBackend)
+
+      val phasesSetMapGetter  = classOf[Global].getDeclaredMethod("phasesSet")
+      val phasesDescMapGetter = classOf[Global].getDeclaredMethod("phasesDescMap")
+      val phasesDescMap =
+        phasesDescMapGetter.invoke(global).asInstanceOf[mutable.Map[SubComponent, String]]
+      val phasesSet = phasesSetMapGetter.invoke(global).asInstanceOf[mutable.Set[SubComponent]]
+      if (phasesSet.exists(_.phaseName.contains("jvm"))) { // `scalac -help` doesn't instantiate standard phases
+        def subcomponentNamed(name: String) = phasesSet.find(_.phaseName == name).head
+        val oldScs @ List(_)                = List(subcomponentNamed("jvm"))
+        val newScs                          = List(newBackend)
+        def hijackDescription(pt: SubComponent, sc: SubComponent) =
+          phasesDescMap(sc) = phasesDescMap(pt) + " with TASTY support"
+        oldScs zip newScs foreach { case (pt, sc) => hijackDescription(pt, sc) }
+        phasesSet --= oldScs
+        phasesSet ++= newScs
+      }
+
+      (oldBackend, newBackend)
+    } else {
+      (global.genBCode, global.genBCode)
+    }
+  }
+}

--- a/plugin/src/main/scala/org/scalameta/paradise/converters/ConvertException.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/converters/ConvertException.scala
@@ -3,7 +3,8 @@ package converters
 
 import org.scalameta.data._
 
-@data class ConvertException(culprit: Any, message: String, cause: Option[Throwable] = None)
-extends Exception(message, cause.orNull) {
+@data
+class ConvertException(culprit: Any, message: String, cause: Option[Throwable] = None)
+    extends Exception(message, cause.orNull) {
   override def toString = super.toString
 }

--- a/plugin/src/main/scala/org/scalameta/paradise/converters/Converter.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/converters/Converter.scala
@@ -4,5 +4,4 @@ package converters
 import scala.tools.nsc.Global
 import org.scalameta.paradise.reflect.ReflectToolkit
 
-trait Converter extends ReflectToolkit
-                   with ToMtree
+trait Converter extends ReflectToolkit with ToMtree

--- a/plugin/src/main/scala/org/scalameta/paradise/converters/PersistPhase.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/converters/PersistPhase.scala
@@ -1,0 +1,49 @@
+package org.scalameta.paradise
+package converters
+
+import scala.meta._
+import scala.tools.nsc.{Global, Phase, SubComponent}
+import scala.tools.nsc.plugins.{Plugin => NscPlugin, PluginComponent => NscPluginComponent}
+import org.scalameta.paradise.reflect.ReflectToolkit
+
+trait PersistPhase extends ReflectToolkit with Converter {
+  object PersistComponent extends NscPluginComponent {
+    lazy val global: PersistPhase.this.global.type = PersistPhase.this.global
+    import global._
+
+    // TODO: ideally we would like to save everything after the very end of typechecking, which is after refchecks
+    // but unfortunately by then a lot of semantic stuff is already desugared to death (patmat, superaccessors, some code in refchecks)
+    // therefore we run after typer and hope for the best (i.e. that we don't run into nonsense that we don't know how to convert,
+    // and also that we don't encounter residual cyclic reference errors which are the reason why certain typechecks are delayed past typer)
+    // btw this isn't such a big problem for persistence, but it definitely is for macro interpretation
+    // let's hope that the research into runtime macros, which entails moving the typechecker to scala-reflect.jar will allow us to restructure things
+    // so that delayed typechecks come right after typer, not intermingled with other logic
+    override val runsAfter      = List("typer")
+    override val runsRightAfter = None
+    override val phaseName      = "persist"
+    override def description    = "persist scala.meta trees"
+
+    private var _backendCheck = false
+    private def ensureBCodeBackend(): Unit = {
+      if (!_backendCheck) {
+        _backendCheck = true
+        if (!settings.isBCodeActive) {
+          global.reporter
+            .error(NoPosition, "scala.meta tree persistence requires -Ybackend:GenBCode")
+        }
+      }
+    }
+
+    override def newPhase(prev: Phase): Phase = new Phase(prev) {
+      override def name = "persist"
+      override def run(): Unit = {
+        global.currentRun.units.foreach(unit => {
+          if (sys.props("persist.debug") != null)
+            println(s"computing scala.meta tree for ${unit.source.file.path}")
+          unit.body.metadata("scalameta") = unit.body.toMtree[Source]
+          ensureBCodeBackend() // NOTE: actual persistence is delayed until bytecode emission
+        })
+      }
+    }
+  }
+}

--- a/plugin/src/main/scala/org/scalameta/paradise/converters/ToMtree.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/converters/ToMtree.scala
@@ -22,17 +22,16 @@ import scala.{meta => m}
 // that is capable of merging syntactically precise trees (obtained from parsing)
 // and semantically precise trees (obtain from converting).
 
-trait ToMtree {
-  self: Converter =>
+trait ToMtree { self: Converter =>
 
   protected implicit class XtensionGtreeToMtree(gtree: g.Tree) {
-    def toMtree[T <: m.Tree : ClassTag]: T = self.toMtree[T](gtree)
+    def toMtree[T <: m.Tree: ClassTag]: T = self.toMtree[T](gtree)
   }
 
-  private def toMtree[T <: m.Tree : ClassTag](gtree: g.Tree): T = {
+  private def toMtree[T <: m.Tree: ClassTag](gtree: g.Tree): T = {
     object toMtree {
       implicit class XtensionGtreeToMtree(gtree0: g.Tree) {
-        def toMtree[T <: m.Tree : ClassTag]: T = {
+        def toMtree[T <: m.Tree: ClassTag]: T = {
           wrap[T](gtree0, (gtree, gexpansion) => {
             val mtree = gtree match {
               // ============ NAMES ============
@@ -56,17 +55,17 @@ trait ToMtree {
                 lname.toMtree[m.Term.Name]
 
               case l.TermSelect(lpre, lname) =>
-                val mpre = lpre.toMtree[m.Term]
+                val mpre  = lpre.toMtree[m.Term]
                 val mname = lname.toMtree[m.Term.Name]
                 m.Term.Select(mpre, mname)
 
               case l.TermApply(lfun, largs) if !termSelectContainsConstructor(lfun) =>
-                val mfun = lfun.toMtree[m.Term]
+                val mfun  = lfun.toMtree[m.Term]
                 val margs = largs.toMtrees[m.Term.Arg]
                 m.Term.Apply(mfun, margs)
 
               case l.TermApplyType(lfun, ltargs) =>
-                val mfun = lfun.toMtree[m.Term]
+                val mfun   = lfun.toMtree[m.Term]
                 val mtargs = ltargs.toMtrees[m.Type]
                 m.Term.ApplyType(mfun, mtargs)
 
@@ -92,7 +91,7 @@ trait ToMtree {
 
               case l.TermFunction(lparams, lbody) =>
                 val mparams = lparams.toMtrees[m.Term.Param]
-                val mbody = lbody.toMtree[m.Term]
+                val mbody   = lbody.toMtree[m.Term]
                 m.Term.Function(mparams, mbody)
 
               case l.TermWhile(lcond, lbody) =>
@@ -106,7 +105,7 @@ trait ToMtree {
 
               case l.TermArg.Named(lname, lrhs) =>
                 val mname = lname.toMtree[m.Term.Name]
-                val mrhs = lrhs.toMtree[m.Term.Arg]
+                val mrhs  = lrhs.toMtree[m.Term.Arg]
                 m.Term.Arg.Named(mname, mrhs)
 
               case l.TermArg.Repeated(lident) =>
@@ -114,9 +113,9 @@ trait ToMtree {
                 m.Term.Arg.Repeated(mterm)
 
               case l.TermParamDef(lmods, lname, ltpt, ldefault) =>
-                val mmods = lmods.toMtrees[m.Mod]
-                val mname = lname.toMtree[m.Term.Param.Name]
-                val mtpt = ltpt.toMtreeopt[m.Type]
+                val mmods    = lmods.toMtrees[m.Mod]
+                val mname    = lname.toMtree[m.Term.Param.Name]
+                val mtpt     = ltpt.toMtreeopt[m.Type]
                 val mdefault = ldefault.toMtreeopt[m.Term]
                 m.Term.Param(mmods, mname, mtpt, mdefault)
 
@@ -129,12 +128,12 @@ trait ToMtree {
                 lname.toMtree[m.Type.Name]
 
               case l.TypeSelect(lpre, lname) =>
-                val mpre = lpre.toMtree[m.Term.Ref]
+                val mpre  = lpre.toMtree[m.Term.Ref]
                 val mname = lname.toMtree[m.Type.Name]
                 m.Type.Select(mpre, mname)
 
               case l.TypeApply(ltpt, largs) =>
-                val mtpt = ltpt.toMtree[m.Type]
+                val mtpt  = ltpt.toMtree[m.Type]
                 val margs = largs.toMtrees[m.Type]
                 m.Type.Apply(mtpt, margs)
 
@@ -144,8 +143,8 @@ trait ToMtree {
                 m.Type.Bounds(mlo, mhi)
 
               case l.TypeParamDef(lmods, lname, ltparams, ltbounds, lvbounds, lcbounds) =>
-                val mmods = lmods.toMtrees[m.Mod]
-                val mname = lname.toMtree[m.Type.Param.Name]
+                val mmods    = lmods.toMtrees[m.Mod]
+                val mname    = lname.toMtree[m.Type.Param.Name]
                 val mtparams = ltparams.toMtrees[m.Type.Param]
                 val mtbounds = ltbounds.toMtree[m.Type.Bounds]
                 val mvbounds = lvbounds.toMtrees[m.Type]
@@ -172,14 +171,14 @@ trait ToMtree {
                 m.Pat.Alternative(mllhs, mlrhs)
 
               case l.PatExtract(lref, ltargs, largs) =>
-                val mref = lref.toMtree[m.Term.Ref]
+                val mref   = lref.toMtree[m.Term.Ref]
                 val mtargs = ltargs.toMtrees[m.Pat.Type] // dveim replaced
-                val margs = largs.toMtrees[m.Pat.Arg]
+                val margs  = largs.toMtrees[m.Pat.Arg]
                 m.Pat.Extract(mref, mtargs, margs)
 
               case l.PatTyped(llhs, lrhs) =>
                 val mlrhs = llhs.toMtree[m.Pat]
-                val mrhs = lrhs.toMtree[m.Pat.Type] // dveim replaced
+                val mrhs  = lrhs.toMtree[m.Pat.Type] // dveim replaced
                 m.Pat.Typed(mlrhs, mrhs)
 
               // ============ LITERALS ============
@@ -190,11 +189,11 @@ trait ToMtree {
               // ============ DECLS ============
 
               case l.AbstractDefDef(lmods, lname, ltparams, lparamss, ltpt) =>
-                val mmods = lmods.toMtrees[m.Mod]
-                val mname = lname.toMtree[m.Term.Name]
+                val mmods    = lmods.toMtrees[m.Mod]
+                val mname    = lname.toMtree[m.Term.Name]
                 val mtparams = ltparams.toMtrees[m.Type.Param]
                 val mparamss = lparamss.toMtreess[m.Term.Param]
-                val mtpt = ltpt.toMtree[m.Type]
+                val mtpt     = ltpt.toMtree[m.Type]
                 m.Decl.Def(mmods, mname, mtparams, mparamss, mtpt)
 
               // ============ DEFNS ============
@@ -202,37 +201,37 @@ trait ToMtree {
               case l.ValDef(lmods, lpats, ltpt, lrhs) =>
                 val mmods = lmods.toMtrees[m.Mod]
                 val mpats = lpats.toMtrees[m.Pat]
-                val mtpt = ltpt.toMtreeopt[m.Type]
-                val mrhs = lrhs.toMtree[m.Term]
+                val mtpt  = ltpt.toMtreeopt[m.Type]
+                val mrhs  = lrhs.toMtree[m.Term]
                 m.Defn.Val(mmods, mpats, mtpt, mrhs)
 
               case l.VarDef(lmods, lpats, ltpt, lrhs) =>
                 val mmods = lmods.toMtrees[m.Mod]
                 val mpats = lpats.toMtrees[m.Pat]
-                val mtpt = ltpt.toMtreeopt[m.Type]
-                val mrhs = lrhs.toMtreeopt[m.Term]
+                val mtpt  = ltpt.toMtreeopt[m.Type]
+                val mrhs  = lrhs.toMtreeopt[m.Term]
                 m.Defn.Var(mmods, mpats, mtpt, mrhs)
 
               case l.DefDef(lmods, lname, ltparams, lparamss, ltpt, lrhs) =>
-                val mmods = lmods.toMtrees[m.Mod]
-                val mname = lname.toMtree[m.Term.Name]
+                val mmods    = lmods.toMtrees[m.Mod]
+                val mname    = lname.toMtree[m.Term.Name]
                 val mtparams = ltparams.toMtrees[m.Type.Param]
                 val mparamss = lparamss.toMtreess[m.Term.Param]
-                val mtpt = ltpt.toMtreeopt[m.Type]
-                val mrhs = lrhs.toMtree[m.Term]
+                val mtpt     = ltpt.toMtreeopt[m.Type]
+                val mrhs     = lrhs.toMtree[m.Term]
                 m.Defn.Def(mmods, mname, mtparams, mparamss, mtpt, mrhs)
 
               case l.ClassDef(lmods, lname, ltparams, lctor, limpl) =>
-                val mmods = lmods.toMtrees[m.Mod]
-                val mname = lname.toMtree[m.Type.Name]
+                val mmods    = lmods.toMtrees[m.Mod]
+                val mname    = lname.toMtree[m.Type.Name]
                 val mtparams = ltparams.toMtrees[m.Type.Param]
-                val mctor = lctor.toMtree[m.Ctor.Primary]
-                val mimpl = limpl.toMtree[m.Template]
+                val mctor    = lctor.toMtree[m.Ctor.Primary]
+                val mimpl    = limpl.toMtree[m.Template]
                 m.Defn.Class(mmods, mname, mtparams, mctor, mimpl)
 
               case l.TraitDef(lmods, lname, ltparams, lctor, limpl) =>
-                val mmods = lmods.toMtrees[m.Mod]
-                val mname = lname.toMtree[m.Type.Name]
+                val mmods    = lmods.toMtrees[m.Mod]
+                val mname    = lname.toMtree[m.Type.Name]
                 val mtparams = ltparams.toMtrees[m.Type.Param]
                 val mctor =
                   if (lctor == g.EmptyTree) m.Ctor.Primary(Nil, m.Ctor.Name("this"), Nil)
@@ -249,7 +248,7 @@ trait ToMtree {
               // ============ PKGS ============
 
               case l.PackageDef(lname, lstats) =>
-                val mname = lname.toMtree[m.Term.Name]
+                val mname  = lname.toMtree[m.Term.Name]
                 val mstats = lstats.toMtrees[m.Stat]
                 m.Pkg(mname, mstats)
 
@@ -259,7 +258,7 @@ trait ToMtree {
                 val mmods = lmods.toMtrees[m.Mod]
                 // TODO: fixme https://github.com/xeno-by/scalameta/blob/7b9632ff889268a1c8c7c71432998e553146eab0/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala#L3096
                 // val mname = lname.toMtree[m.Ctor.Name]
-                val mname = m.Ctor.Name("this")
+                val mname    = m.Ctor.Name("this")
                 val mparamss = lparamss.toMtreess[m.Term.Param]
                 m.Ctor.Primary(mmods, mname, mparamss)
 
@@ -271,15 +270,15 @@ trait ToMtree {
               // ============ TEMPLATES ============
 
               case l.Template(learly, lparents, lself, lstats) =>
-                val mearly = learly.toMtrees[m.Stat]
+                val mearly   = learly.toMtrees[m.Stat]
                 val mparents = lparents.toMtrees[m.Ctor.Call]
-                val mself = lself.toMtree[m.Term.Param]
-                val mstats = lstats.map(_.toMtrees[m.Stat])
+                val mself    = lself.toMtree[m.Term.Param]
+                val mstats   = lstats.map(_.toMtrees[m.Stat])
                 m.Template(mearly, mparents, mself, mstats)
 
               case l.Parent(ltpt, lctor, largss) =>
-                val mtpt = ltpt.toMtree[m.Type]
-                val mctor = mtpt.ctorRef(lctor.toMtree[m.Ctor.Name])
+                val mtpt   = ltpt.toMtree[m.Type]
+                val mctor  = mtpt.ctorRef(lctor.toMtree[m.Ctor.Name])
                 val margss = largss.toMtreess[m.Term.Arg]
                 margss.foldLeft(mctor)((mcurr, margs) => {
                   m.Term.Apply(mcurr, margs)
@@ -287,14 +286,18 @@ trait ToMtree {
 
               case l.SelfDef(lname, ltpt) =>
                 val mname = lname.toMtree[m.Term.Param.Name]
-                val mtpt = if (ltpt.nonEmpty) Some(ltpt.toMtree[m.Type]) else None
+                val mtpt  = if (ltpt.nonEmpty) Some(ltpt.toMtree[m.Type]) else None
                 m.Term.Param(Nil, mname, mtpt, None)
 
               // ============ MODIFIERS ============
 
               case l.Annotation(lapply) =>
                 // scala.reflect uses Term.New here, but we need only its parent
-                val m.Term.New(m.Template(Nil, Seq(mparent), m.Term.Param(Nil, m.Name.Anonymous(), None, None), None)) =
+                val m.Term.New(
+                  m.Template(Nil,
+                             Seq(mparent),
+                             m.Term.Param(Nil, m.Name.Anonymous(), None, None),
+                             None)) =
                   lapply.toMtree[m.Term.New]
                 m.Mod.Annot(mparent)
 
@@ -344,19 +347,23 @@ trait ToMtree {
               case l.Import(lident, lselectors) =>
                 val mname = lident.toMtree[m.Term.Ref]
                 val mimportees = lselectors.map {
-                  case l.ImportSelector(g.termNames.WILDCARD, g.termNames.NO_NAME) => m.Importee.Wildcard()
-                  case l.ImportSelector(name, g.termNames.NO_NAME) => m.Importee.Name(name.toMtree[m.Name.Indeterminate])
-                  case l.ImportSelector(name, g.termNames.WILDCARD) => m.Importee.Unimport(name.toMtree[m.Name.Indeterminate])
-                  case l.ImportSelector(name, rename) => m.Importee.Rename(name.toMtree[m.Name.Indeterminate], rename.toMtree[m.Name.Indeterminate])
+                  case l.ImportSelector(g.termNames.WILDCARD, g.termNames.NO_NAME) =>
+                    m.Importee.Wildcard()
+                  case l.ImportSelector(name, g.termNames.NO_NAME) =>
+                    m.Importee.Name(name.toMtree[m.Name.Indeterminate])
+                  case l.ImportSelector(name, g.termNames.WILDCARD) =>
+                    m.Importee.Unimport(name.toMtree[m.Name.Indeterminate])
+                  case l.ImportSelector(name, rename) =>
+                    m.Importee.Rename(name.toMtree[m.Name.Indeterminate],
+                                      rename.toMtree[m.Name.Indeterminate])
                 }
 
                 m.Import(List(m.Importer(mname, mimportees)))
 
-
               case l.CaseDef(lpat, lguard, lbody) =>
-                val mpat = lpat.toMtree[m.Pat]
+                val mpat   = lpat.toMtree[m.Pat]
                 val mguard = lguard.toMtreeopt[m.Term]
-                val mbody = lbody.toMtree[m.Term]
+                val mbody  = lbody.toMtree[m.Term]
                 m.Case(mpat, mguard, mbody)
 
               case _ =>
@@ -368,26 +375,26 @@ trait ToMtree {
       }
 
       implicit class RichTreeoptToMtreeopt(gtreeopt: Option[g.Tree]) {
-        def toMtreeopt[T <: m.Tree : ClassTag]: Option[T] = gtreeopt.map(_.toMtree[T])
+        def toMtreeopt[T <: m.Tree: ClassTag]: Option[T] = gtreeopt.map(_.toMtree[T])
       }
 
       implicit class RichTreesToMtrees(gtrees: List[g.Tree]) {
-        def toMtrees[T <: m.Tree : ClassTag]: Seq[T] = gtrees.map(_.toMtree[T])
+        def toMtrees[T <: m.Tree: ClassTag]: Seq[T] = gtrees.map(_.toMtree[T])
       }
 
       implicit class RichTreessToMtreess(gtreess: List[List[g.Tree]]) {
-        def toMtreess[T <: m.Tree : ClassTag]: Seq[Seq[T]] = gtreess.map(_.toMtrees[T])
+        def toMtreess[T <: m.Tree: ClassTag]: Seq[Seq[T]] = gtreess.map(_.toMtrees[T])
       }
 
       var backtrace = List[g.Tree]()
-      def wrap[T <: m.Tree : ClassTag](gtree0: g.Tree, converter: (g.Tree, g.Tree) => m.Tree): T = {
+      def wrap[T <: m.Tree: ClassTag](gtree0: g.Tree, converter: (g.Tree, g.Tree) => m.Tree): T = {
         val isDuplicate = backtrace.nonEmpty && backtrace.head == gtree0
         if (!isDuplicate) backtrace = gtree0 +: backtrace
         try {
-          val (gtree, gexpansion) = (gtree0, g.EmptyTree)
-          val convertedTree = converter(gtree, gexpansion)
+          val (gtree, gexpansion)   = (gtree0, g.EmptyTree)
+          val convertedTree         = converter(gtree, gexpansion)
           val maybeTypecheckedMtree = convertedTree
-          val maybeIndexedMtree = maybeTypecheckedMtree
+          val maybeIndexedMtree     = maybeTypecheckedMtree
           if (classTag[T].runtimeClass.isAssignableFrom(maybeIndexedMtree.getClass)) {
             maybeIndexedMtree.asInstanceOf[T]
           } else {
@@ -395,7 +402,7 @@ trait ToMtree {
             expected = expected.stripPrefix("scala.meta.internal.ast.").stripPrefix("scala.meta.")
             expected = expected.stripSuffix("$Impl")
             expected = expected.replace("$", ".")
-            val actual = maybeIndexedMtree.productPrefix
+            val actual  = maybeIndexedMtree.productPrefix
             val summary = s"expected = $expected, actual = $actual"
             val details = s"${g.showRaw(gtree)}$EOL${maybeIndexedMtree.show[Structure]}"
             fail(s"unexpected result: $summary$EOL$details")
@@ -414,19 +421,21 @@ trait ToMtree {
 
       def termSelectContainsConstructor(lfun: g.Tree): Boolean = lfun match {
         case g.Select(_, g.nme.CONSTRUCTOR) => true
-        case _ => false
+        case _                              => false
       }
 
       def fail(diagnostics: String, ex: Option[Throwable] = None): Nothing = {
-        val s_backtrace = backtrace.map(gtree => {
-          val prefix = gtree.productPrefix
-          val details = gtree.toString()
-          s"($prefix) $details"
-        }).mkString(EOL)
+        val s_backtrace = backtrace
+          .map(gtree => {
+            val prefix  = gtree.productPrefix
+            val details = gtree.toString()
+            s"($prefix) $details"
+          })
+          .mkString(EOL)
         throw new ConvertException(backtrace.head, s"$diagnostics$EOL$s_backtrace", ex)
       }
 
-      def apply[T <: m.Tree : ClassTag](gtree: g.Tree): T = {
+      def apply[T <: m.Tree: ClassTag](gtree: g.Tree): T = {
         val mtree = wrap[T](gtree, (gtree, gexpansion) => {
           gtree match {
             case g.PackageDef(g.Ident(g.nme.EMPTY_PACKAGE_NAME), gstats) =>

--- a/plugin/src/main/scala/org/scalameta/paradise/parser/HijackSyntaxAnalyzer.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/parser/HijackSyntaxAnalyzer.scala
@@ -4,25 +4,29 @@ package parser
 import scala.tools.nsc.{Global => NscGlobal, Phase, SubComponent, Settings => NscSettings}
 import scala.tools.nsc.plugins.{Plugin => NscPlugin, PluginComponent => NscPluginComponent}
 import scala.collection.mutable
-import org.scalameta.paradise.parser.{SyntaxAnalyzer => ParadiseSyntaxAnalyzer, ReplGlobal => ParadiseReplGlobal}
+import org.scalameta.paradise.parser.{
+  SyntaxAnalyzer => ParadiseSyntaxAnalyzer,
+  ReplGlobal => ParadiseReplGlobal
+}
 import scala.tools.nsc.interpreter.{ReplGlobal => NscReplGlobal, _}
 import scala.reflect.internal.util.BatchSourceFile
 
-trait HijackSyntaxAnalyzer {
-  self: NscPlugin =>
+trait HijackSyntaxAnalyzer { self: NscPlugin =>
 
   // NOTE: Thank you myself from two years ago.
   // https://github.com/scalameta/scalahost/blob/a97d73d7356ede881f9edf335e93db64244ec68d/plugin/src/main/scala/parser/HijackSyntaxAnalyzer.scala
   def hijackSyntaxAnalyzer(): Unit = {
-    val newSyntaxAnalyzer = new { val global: self.global.type = self.global } with ParadiseSyntaxAnalyzer
+    val newSyntaxAnalyzer = new { val global: self.global.type = self.global }
+    with ParadiseSyntaxAnalyzer
     val syntaxAnalyzerField = classOf[NscGlobal].getDeclaredField("syntaxAnalyzer")
     syntaxAnalyzerField.setAccessible(true)
     syntaxAnalyzerField.set(global, newSyntaxAnalyzer)
 
     val phasesDescMapGetter = classOf[NscGlobal].getDeclaredMethod("phasesDescMap")
-    val phasesDescMap = phasesDescMapGetter.invoke(global).asInstanceOf[mutable.Map[SubComponent, String]]
+    val phasesDescMap =
+      phasesDescMapGetter.invoke(global).asInstanceOf[mutable.Map[SubComponent, String]]
     val phasesSetMapGetter = classOf[NscGlobal].getDeclaredMethod("phasesSet")
-    val phasesSet = phasesSetMapGetter.invoke(global).asInstanceOf[mutable.Set[SubComponent]]
+    val phasesSet          = phasesSetMapGetter.invoke(global).asInstanceOf[mutable.Set[SubComponent]]
     if (phasesSet.exists(_.phaseName == "parser")) { // `scalac -help` doesn't instantiate standard phases
       phasesSet -= phasesSet.find(_.phaseName == "parser").head
       phasesSet += newSyntaxAnalyzer
@@ -30,18 +34,25 @@ trait HijackSyntaxAnalyzer {
     }
 
     if (global.isInstanceOf[NscReplGlobal] && global.toString != "<hijacked global>") {
-      def obtainField(cls: Class[_], name: String) = { val result = cls.getDeclaredField(name); result.setAccessible(true); result }
-      def obtainMethod(cls: Class[_], name: String) = { val result = cls.getDeclaredMethods().filter(_.getName == name).head; result.setAccessible(true); result }
-      val f_intp = obtainField(classOf[ReplReporter], "intp")
-      val f_compiler = obtainField(classOf[IMain], "_compiler")
+      def obtainField(cls: Class[_], name: String) = {
+        val result = cls.getDeclaredField(name); result.setAccessible(true); result
+      }
+      def obtainMethod(cls: Class[_], name: String) = {
+        val result = cls.getDeclaredMethods().filter(_.getName == name).head;
+        result.setAccessible(true); result
+      }
+      val f_intp        = obtainField(classOf[ReplReporter], "intp")
+      val f_compiler    = obtainField(classOf[IMain], "_compiler")
       val m_initSources = obtainMethod(classOf[IMain], "_initSources")
 
-      val intp = f_intp.get(global.reporter).asInstanceOf[IMain]
+      val intp     = f_intp.get(global.reporter).asInstanceOf[IMain]
       val settings = new NscSettings()
       intp.settings.copyInto(settings)
       settings.outputDirs setSingleOutput intp.replOutput.dir
       settings.exposeEmptyPackage.value = true
-      val hijackedCompiler = new NscGlobal(settings, global.reporter) with ParadiseReplGlobal { override def toString: String = "<hijacked global>" }
+      val hijackedCompiler = new NscGlobal(settings, global.reporter) with ParadiseReplGlobal {
+        override def toString: String = "<hijacked global>"
+      }
       val initSources = m_initSources.invoke(intp).asInstanceOf[List[BatchSourceFile]]
       new hijackedCompiler.Run().compileSources(initSources)
       f_compiler.set(intp, hijackedCompiler)

--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/Definitions.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/Definitions.scala
@@ -4,17 +4,16 @@ package reflect
 import scala.reflect.internal.Flags._
 import scala.reflect.internal.MissingRequirementError
 
-trait Definitions {
-  self: ReflectToolkit =>
+trait Definitions { self: ReflectToolkit =>
 
   import global._
   import rootMirror._
   import definitions._
 
   object paradiseDefinitions {
-    lazy val InheritedAttr = requiredClass[java.lang.annotation.Inherited]
+    lazy val InheritedAttr   = requiredClass[java.lang.annotation.Inherited]
     lazy val MetaInlineClass = rootMirror.getClassIfDefined("scala.meta.internal.inline.inline")
-    lazy val MetaStatClass = rootMirror.getClassIfDefined("scala.meta.Stat")
-    lazy val MetaTypeClass = rootMirror.getClassIfDefined("scala.meta.Type")
+    lazy val MetaStatClass   = rootMirror.getClassIfDefined("scala.meta.Stat")
+    lazy val MetaTypeClass   = rootMirror.getClassIfDefined("scala.meta.Type")
   }
 }

--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/LogicalTrees.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/LogicalTrees.scala
@@ -11,8 +11,7 @@ import org.scalameta.adt._
 import org.scalameta.roles._
 import org.scalameta.debug
 
-trait LogicalTrees {
-  self: ReflectToolkit =>
+trait LogicalTrees { self: ReflectToolkit =>
 
   import global.{require => _, abort => _, _}
   import definitions._
@@ -87,20 +86,22 @@ trait LogicalTrees {
 
   implicit class RichFoundationHelperName(name: g.Name) {
     def isAnonymous = {
-      val isTermPlaceholder = name.isTermName && name.startsWith(nme.FRESH_TERM_NAME_PREFIX)
-      val isTypePlaceholder = name.isTypeName && name.startsWith("_$")
-      val isAnonymousSelf = name.isTermName && (name.startsWith(nme.FRESH_TERM_NAME_PREFIX) || name == nme.this_)
+      val isTermPlaceholder        = name.isTermName && name.startsWith(nme.FRESH_TERM_NAME_PREFIX)
+      val isTypePlaceholder        = name.isTypeName && name.startsWith("_$")
+      val isAnonymousSelf          = name.isTermName && (name.startsWith(nme.FRESH_TERM_NAME_PREFIX) || name == nme.this_)
       val isAnonymousTypeParameter = name == tpnme.WILDCARD
       isTermPlaceholder || isTypePlaceholder || isAnonymousSelf || isAnonymousTypeParameter
     }
     def looksLikeInfix = {
-      val hasSymbolicName = !name.decoded.forall(c => Character.isLetter(c) || Character.isDigit(c) || c == '_')
+      val hasSymbolicName =
+        !name.decoded.forall(c => Character.isLetter(c) || Character.isDigit(c) || c == '_')
       val idiomaticallyUsedAsInfix = name == nme.eq || name == nme.ne
       hasSymbolicName || idiomaticallyUsedAsInfix
     }
     def displayName = {
       // NOTE: "<empty>", the internal name for empty package, isn't a valid Scala identifier, so we hack around
-      if (name == null || name == rootMirror.EmptyPackage.name || name == rootMirror.EmptyPackageClass.name) "_empty_"
+      if (name == null || name == rootMirror.EmptyPackage.name || name == rootMirror.EmptyPackageClass.name)
+        "_empty_"
       // TODO: why did we need this in the past?
       // else if (name.isAnonymous) "_"
       else name.decodedName.toString
@@ -114,7 +115,11 @@ trait LogicalTrees {
 
     trait QualifierName extends Name
 
-    case class AnonymousName() extends Name with TermParamName with TypeParamName with QualifierName
+    case class AnonymousName()
+        extends Name
+        with TermParamName
+        with TypeParamName
+        with QualifierName
     object AnonymousName {
       def apply(pre: g.Type): l.AnonymousName = apply()
     }
@@ -128,15 +133,16 @@ trait LogicalTrees {
 
     implicit class RichNameTree(tree: Tree) {
       def displayName: String = tree match {
-        case tree: ModuleDef if tree.name == nme.PACKAGE => unreachable(debug(tree, showRaw(tree))) // dveim was abort(tree)
-        case tree: NameTree => tree.name.displayName
-        case This(name) => name.displayName // NOTE: This(tpnme.EMPTY) is also accounted for
-        case Super(_, name) => name.displayName
+        case tree: ModuleDef if tree.name == nme.PACKAGE =>
+          unreachable(debug(tree, showRaw(tree))) // dveim was abort(tree)
+        case tree: NameTree            => tree.name.displayName
+        case This(name)                => name.displayName // NOTE: This(tpnme.EMPTY) is also accounted for
+        case Super(_, name)            => name.displayName
         case tree: l.IndeterminateName => tree.value
-        case tree: l.TermName => tree.value
-        case tree: l.TypeName => tree.value
-        case tree: l.CtorName => tree.value
-        case _ => unreachable(debug(tree, showRaw(tree)))
+        case tree: l.TermName          => tree.value
+        case tree: l.TypeName          => tree.value
+        case tree: l.CtorName          => tree.value
+        case _                         => unreachable(debug(tree, showRaw(tree)))
       }
     }
 
@@ -153,7 +159,10 @@ trait LogicalTrees {
     case class TermName(value: String) extends Name with TermParamName
     object TermName {
       def apply(tree: g.NameTree): l.TermName = {
-        require(tree.name.isTermName && tree.name != nme.WILDCARD && tree.name != nme.CONSTRUCTOR && debug(tree, showRaw(tree)))
+        require(
+          tree.name.isTermName && tree.name != nme.WILDCARD && tree.name != nme.CONSTRUCTOR && debug(
+            tree,
+            showRaw(tree)))
         new l.TermName(tree.displayName).setType(tree.tpe)
       }
     }
@@ -215,7 +224,7 @@ trait LogicalTrees {
     object TermFunction {
       def unapply(tree: g.Function): Option[(List[g.Tree], g.Tree)] = {
         val g.Function(params, body) = tree
-        val lparams = params.map(_.set(TermParamRole))
+        val lparams                  = params.map(_.set(TermParamRole))
         Some((lparams, body))
       }
     }
@@ -223,8 +232,12 @@ trait LogicalTrees {
     object TermWhile {
       def unapply(tree: g.LabelDef): Option[(g.Tree, g.Tree)] = {
         tree match {
-          case g.LabelDef(name1, Nil, g.If(cond, g.Block(List(body), g.Apply(Ident(name2), Nil)), g.Literal(g.Constant(()))))
-            if name1 == name2 && name1.startsWith(nme.WHILE_PREFIX) =>
+          case g.LabelDef(name1,
+                          Nil,
+                          g.If(cond,
+                               g.Block(List(body), g.Apply(Ident(name2), Nil)),
+                               g.Literal(g.Constant(()))))
+              if name1 == name2 && name1.startsWith(nme.WHILE_PREFIX) =>
             Some((cond, body))
           case _ =>
             None
@@ -236,7 +249,9 @@ trait LogicalTrees {
       def unapply(tree: g.Tree): Option[l.Template] = tree match {
         case g.Apply(g.Select(g.New(tpt), nme.CONSTRUCTOR), args) =>
           val lparent = g.Apply(tpt, args).set(new SupercallRole)
-          val lself = g.ValDef(g.Modifiers(), g.nme.WILDCARD, g.TypeTree(), g.EmptyTree).set(SelfRole(g.EmptyTree))
+          val lself =
+            g.ValDef(g.Modifiers(), g.nme.WILDCARD, g.TypeTree(), g.EmptyTree)
+              .set(SelfRole(g.EmptyTree))
           Some(l.Template(Nil, List(lparent), lself, None))
         case _ =>
           None
@@ -247,14 +262,14 @@ trait LogicalTrees {
       object Named {
         def unapply(tree: g.Tree): Option[(g.Tree, g.Tree)] = tree match {
           case g.AssignOrNamedArg(lhs, rhs) => Some((lhs, rhs))
-          case _ => None
+          case _                            => None
         }
       }
 
       object Repeated {
         def unapply(tree: g.Tree): Option[g.Ident] = tree match {
           case g.Typed(ident: g.Ident, g.Ident(g.typeNames.WILDCARD_STAR)) => Some(ident)
-          case _ => None
+          case _                                                           => None
         }
       }
     }
@@ -262,11 +277,12 @@ trait LogicalTrees {
     trait TermParamName extends Name
 
     object TermParamDef {
-      def unapply(tree: g.ValDef): Option[(List[l.Modifier], l.TermName, Option[g.Tree], Option[g.Tree])] = {
+      def unapply(tree: g.ValDef)
+        : Option[(List[l.Modifier], l.TermName, Option[g.Tree], Option[g.Tree])] = {
         if (!tree.is(TermParamRole)) return None
         val g.ValDef(_, _, tpt, default) = tree
-        val ltpt = if (tpt.nonEmpty) Some(tpt) else None
-        val ldefault = if (default.nonEmpty) Some(default) else None // TODO: handle defaults after typechecking
+        val ltpt                         = if (tpt.nonEmpty) Some(tpt) else None
+        val ldefault                     = if (default.nonEmpty) Some(default) else None // TODO: handle defaults after typechecking
         Some((l.Modifiers(tree), l.TermName(tree), ltpt, ldefault))
       }
     }
@@ -312,8 +328,8 @@ trait LogicalTrees {
     object TypeBounds {
       def unapply(tree: g.TypeBoundsTree): Option[(Option[g.Tree], Option[g.Tree])] = {
         val g.TypeBoundsTree(glo, ghi) = tree
-        val llo = if (glo.nonEmpty) Some(glo) else None
-        val lhi = if (ghi.nonEmpty) Some(ghi) else None
+        val llo                        = if (glo.nonEmpty) Some(glo) else None
+        val lhi                        = if (ghi.nonEmpty) Some(ghi) else None
         Some((llo, lhi))
       }
     }
@@ -321,11 +337,17 @@ trait LogicalTrees {
     trait TypeParamName extends Name
 
     object TypeParamDef {
-      def unapply(tree: g.TypeDef): Option[(List[l.Modifier], l.Name, List[g.TypeDef], g.TypeBoundsTree, List[g.Tree], List[g.Tree])] = {
+      def unapply(tree: g.TypeDef): Option[(List[l.Modifier],
+                                            l.Name,
+                                            List[g.TypeDef],
+                                            g.TypeBoundsTree,
+                                            List[g.Tree],
+                                            List[g.Tree])] = {
         if (!tree.is(TypeParamRole)) return None
         val g.TypeDef(_, name, tparams, rhs) = tree
-        val lname = if (tree.name.isAnonymous) l.AnonymousName()
-                    else l.TypeName(tree)
+        val lname =
+          if (tree.name.isAnonymous) l.AnonymousName()
+          else l.TypeName(tree)
         val ltparams = tparams.map(_.set(TypeParamRole(Nil, Nil)))
         val ltbounds = {
           rhs match {
@@ -350,7 +372,6 @@ trait LogicalTrees {
       }
     }
 
-
     object PatWildcard {
       def unapply(tree: g.Ident): Boolean = {
         if (!tree.is(PatLoc)) return false
@@ -362,8 +383,8 @@ trait LogicalTrees {
       def unapply(tree: g.Bind): Option[(g.Tree, g.Tree)] = {
         if (tree.name.isTypeName) return None
         val g.Bind(name, body) = tree
-        val llhs = l.PatVarTerm(tree)
-        val lrhs = body.set(PatLoc)
+        val llhs               = l.PatVarTerm(tree)
+        val lrhs               = body.set(PatLoc)
         Some((llhs, lrhs))
       }
     }
@@ -371,10 +392,10 @@ trait LogicalTrees {
     object PatAlternative {
       def unapply(tree: g.Alternative): Option[(g.Tree, g.Tree)] = {
         val g.Alternative(head :: tail) = tree
-        val llhs = head
+        val llhs                        = head
         val lrhs = tail match {
-          case Nil => return None
-          case head :: Nil => head
+          case Nil                    => return None
+          case head :: Nil            => head
           case trees @ (head :: tail) => g.Alternative(trees)
         }
         Some((llhs, lrhs))
@@ -386,10 +407,11 @@ trait LogicalTrees {
         if (!tree.is(PatLoc)) return None
         val (fun, targs, args) = tree match {
           case g.Apply(g.TypeApply(fun, targs), args) => (fun, targs, args)
-          case g.Apply(fun, args) => (fun, Nil, args)
-          case g.UnApply(g.Apply(g.TypeApply(fun, targs), List(unapplySelector)), args) => (fun, targs, args)
+          case g.Apply(fun, args)                     => (fun, Nil, args)
+          case g.UnApply(g.Apply(g.TypeApply(fun, targs), List(unapplySelector)), args) =>
+            (fun, targs, args)
           case g.UnApply(g.Apply(fun, List(unapplySelector)), args) => (fun, Nil, args)
-          case _ => return None
+          case _                                                    => return None
         }
         val largs = args.map(_.set(PatLoc))
         Some((fun, targs, largs))
@@ -400,7 +422,7 @@ trait LogicalTrees {
       def unapply(tree: g.Typed): Option[(g.Tree, g.Tree)] = {
         if (!tree.is(PatLoc)) return None
         val g.Typed(lhs, rhs) = tree
-        val llhs = lhs.set(PatLoc)
+        val llhs              = lhs.set(PatLoc)
         Some((llhs, rhs))
       }
     }
@@ -409,10 +431,10 @@ trait LogicalTrees {
 
     object Literal {
       def unapply(tree: g.Literal): Option[Any] = tree match {
-        case g.Literal(g.Constant(_: g.Type)) => None
+        case g.Literal(g.Constant(_: g.Type))   => None
         case g.Literal(g.Constant(_: g.Symbol)) => None
-        case g.Literal(g.Constant(value)) => Some(value)
-        case _ => None
+        case g.Literal(g.Constant(value))       => Some(value)
+        case _                                  => None
       }
     }
 
@@ -431,7 +453,8 @@ trait LogicalTrees {
     }
 
     object AbstractDefDef {
-      def unapply(tree: g.DefDef): Option[(List[l.Modifier], l.TermName, List[g.TypeDef], List[List[g.ValDef]], g.Tree)] = {
+      def unapply(tree: g.DefDef)
+        : Option[(List[l.Modifier], l.TermName, List[g.TypeDef], List[List[g.ValDef]], g.Tree)] = {
         if (!tree.is(AbstractMethodRole)) return None
         val g.DefDef(_, _, tparams, paramss, tpt, rhs) = tree
         require(tpt.nonEmpty && rhs.isEmpty)
@@ -442,7 +465,8 @@ trait LogicalTrees {
     }
 
     object AbstractTypeDef {
-      def unapply(tree: g.TypeDef): Option[(List[l.Modifier], l.TypeName, List[g.TypeDef], g.TypeBoundsTree)] = {
+      def unapply(tree: g.TypeDef)
+        : Option[(List[l.Modifier], l.TypeName, List[g.TypeDef], g.TypeBoundsTree)] = {
         ???
       }
     }
@@ -450,72 +474,85 @@ trait LogicalTrees {
     // ============ DEFNS ============
 
     object ValDef {
-      def unapply(tree: g.ValDef): Option[(List[l.Modifier], List[g.Tree], Option[g.Tree], g.Tree)] = {
+      def unapply(
+          tree: g.ValDef): Option[(List[l.Modifier], List[g.Tree], Option[g.Tree], g.Tree)] = {
         if (!tree.is(FieldRole)) return None
         val g.ValDef(_, name, tpt, rhs) = tree
         if (tree.mods.hasFlag(MUTABLE)) return None
         // TODO: support multi-pat valdefs
         val lpats = List(l.PatVarTerm(tree))
-        val ltpt = if (tpt.nonEmpty) Some(tpt) else None
+        val ltpt  = if (tpt.nonEmpty) Some(tpt) else None
         Some((l.Modifiers(tree), lpats, ltpt, rhs))
       }
     }
 
     object VarDef {
-      def unapply(tree: g.ValDef): Option[(List[l.Modifier], List[g.Tree], Option[g.Tree], Option[g.Tree])] = {
+      def unapply(tree: g.ValDef)
+        : Option[(List[l.Modifier], List[g.Tree], Option[g.Tree], Option[g.Tree])] = {
         // TODO: fix the duplication wrt ValDef
         if (!tree.is(FieldRole)) return None
         val g.ValDef(_, name, tpt, rhs) = tree
         if (!tree.mods.hasFlag(MUTABLE)) return None
         // TODO: support multi-pat valdefs
         val lpats = List(l.PatVarTerm(tree))
-        val ltpt = if (tpt.nonEmpty) Some(tpt) else None
-        val lrhs = if (rhs.nonEmpty) Some(rhs) else None
+        val ltpt  = if (tpt.nonEmpty) Some(tpt) else None
+        val lrhs  = if (rhs.nonEmpty) Some(rhs) else None
         Some((l.Modifiers(tree), lpats, ltpt, lrhs))
       }
     }
 
     object DefDef {
-      def unapply(tree: g.DefDef): Option[(List[l.Modifier], l.TermName, List[g.TypeDef], List[List[g.ValDef]], Option[g.Tree], g.Tree)] = {
+      def unapply(tree: g.DefDef): Option[(List[l.Modifier],
+                                           l.TermName,
+                                           List[g.TypeDef],
+                                           List[List[g.ValDef]],
+                                           Option[g.Tree],
+                                           g.Tree)] = {
         if (!tree.is(MethodRole)) return None
         val g.DefDef(_, _, tparams, paramss, tpt, rhs) = tree
-        val ltparams = applyBounds(tparams, paramss)
-        val lparamss = removeBounds(paramss)
-        val ltpt = if (tpt.nonEmpty) Some(tpt) else None
+        val ltparams                                   = applyBounds(tparams, paramss)
+        val lparamss                                   = removeBounds(paramss)
+        val ltpt                                       = if (tpt.nonEmpty) Some(tpt) else None
         Some((l.Modifiers(tree), l.TermName(tree), ltparams, lparamss, ltpt, rhs))
       }
     }
 
     object MacroDef {
-      def unapply(tree: g.DefDef): Option[(List[l.Modifier], l.TermName, List[g.TypeDef], List[List[g.ValDef]], g.Tree, g.Tree)] = {
+      def unapply(tree: g.DefDef): Option[
+        (List[l.Modifier], l.TermName, List[g.TypeDef], List[List[g.ValDef]], g.Tree, g.Tree)] = {
         ???
       }
     }
 
     object TypeDef {
-      def unapply(tree: g.TypeDef): Option[(List[l.Modifier], l.TypeName, List[g.TypeDef], g.Tree)] = {
+      def unapply(
+          tree: g.TypeDef): Option[(List[l.Modifier], l.TypeName, List[g.TypeDef], g.Tree)] = {
         ???
       }
     }
 
     object ClassDef {
-      def unapply(tree: g.ClassDef): Option[(List[l.Modifier], l.TypeName, List[g.TypeDef], g.Tree, l.Template)] = {
+      def unapply(tree: g.ClassDef)
+        : Option[(List[l.Modifier], l.TypeName, List[g.TypeDef], g.Tree, l.Template)] = {
         if (!tree.is(ClassRole)) return None
         val g.ClassDef(_, _, tparams, templ @ g.Template(_, _, body)) = tree
-        val gprimaryctor = body.collectFirst { case ctor @ g.DefDef(_, nme.CONSTRUCTOR, _, _, _, _) => ctor }.get
+        val gprimaryctor = body.collectFirst {
+          case ctor @ g.DefDef(_, nme.CONSTRUCTOR, _, _, _, _) => ctor
+        }.get
         val lprimaryctor = gprimaryctor.set(PrimaryCtorRole(l.TypeName(tree)))
-        val ltparams = applyBounds(tparams, lprimaryctor.vparamss)
-        val ltempl = l.Template(templ, l.TypeName(tree))
+        val ltparams     = applyBounds(tparams, lprimaryctor.vparamss)
+        val ltempl       = l.Template(templ, l.TypeName(tree))
         Some((l.Modifiers(tree), l.TypeName(tree), ltparams, lprimaryctor, ltempl))
       }
     }
 
     object TraitDef {
-      def unapply(tree: g.ClassDef): Option[(List[l.Modifier], l.TypeName, List[g.TypeDef], g.Tree, l.Template)] = {
+      def unapply(tree: g.ClassDef)
+        : Option[(List[l.Modifier], l.TypeName, List[g.TypeDef], g.Tree, l.Template)] = {
         if (!tree.is(TraitRole)) return None
         val g.ClassDef(_, _, tparams, templ) = tree
-        val ltparams = applyBounds(tparams, Nil)
-        val ltempl = l.Template(templ, l.TypeName(tree))
+        val ltparams                         = applyBounds(tparams, Nil)
+        val ltempl                           = l.Template(templ, l.TypeName(tree))
         Some((l.Modifiers(tree), l.TypeName(tree), tparams, g.EmptyTree, ltempl))
       }
     }
@@ -524,7 +561,7 @@ trait LogicalTrees {
       def unapply(tree: g.ModuleDef): Option[(List[l.Modifier], l.TermName, l.Template)] = {
         if (!tree.is(ObjectRole)) return None
         val g.ModuleDef(_, name, templ) = tree
-        val ltempl = l.Template(templ, l.TermName(tree))
+        val ltempl                      = l.Template(templ, l.TermName(tree))
         Some((l.Modifiers(tree), l.TermName(tree), ltempl))
       }
     }
@@ -543,7 +580,7 @@ trait LogicalTrees {
       def unapply(tree: g.PackageDef): Option[(List[l.Modifier], l.TermName, l.Template)] = {
         if (!tree.is(PackageObjectPackageRole)) return None
         val PackageObjectPackageRole(g.ModuleDef(_, _, templ)) = tree.get(PackageObjectPackageRole)
-        val ltempl = l.Template(templ, l.TermName(tree))
+        val ltempl                                             = l.Template(templ, l.TermName(tree))
         Some((Nil, ???, ltempl))
       }
     }
@@ -552,7 +589,8 @@ trait LogicalTrees {
 
     private object CtorDef {
       // isPrimaryCtor, mods, name, paramss, supercall, rhs
-      def unapply(tree: g.DefDef): Option[(Boolean, List[l.Modifier], l.CtorName, List[List[g.ValDef]], g.Tree, List[g.Tree])] = {
+      def unapply(tree: g.DefDef): Option[
+        (Boolean, List[l.Modifier], l.CtorName, List[List[g.ValDef]], g.Tree, List[g.Tree])] = {
         val g.DefDef(_, _, _, vparamss, _, body) = tree
         val (lisPrimaryCtor, lowner) = {
           if (tree.is(PrimaryCtorRole)) {
@@ -565,25 +603,27 @@ trait LogicalTrees {
             return None
           }
         }
-        val lname = l.CtorName(tree, lowner)
-        val lparamss = removeBounds(tree.vparamss)
+        val lname                                     = l.CtorName(tree, lowner)
+        val lparamss                                  = removeBounds(tree.vparamss)
         val g.Block(binit, g.Literal(g.Constant(()))) = body
-        val lsupercall +: lstats = binit.dropWhile(_.isInstanceOf[ValDef])
+        val lsupercall +: lstats                      = binit.dropWhile(_.isInstanceOf[ValDef])
         Some((lisPrimaryCtor, l.Modifiers(tree), lname, lparamss, lsupercall, lstats))
       }
     }
 
     object PrimaryCtorDef {
-      def unapply(tree: g.DefDef): Option[(List[l.Modifier], l.CtorName, List[List[g.ValDef]])] = tree match {
-        case l.CtorDef(true, mods, name, paramss, _, _) => Some((mods, name, paramss))
-        case _ => None
-      }
+      def unapply(tree: g.DefDef): Option[(List[l.Modifier], l.CtorName, List[List[g.ValDef]])] =
+        tree match {
+          case l.CtorDef(true, mods, name, paramss, _, _) => Some((mods, name, paramss))
+          case _                                          => None
+        }
     }
 
     object SecondaryCtorDef {
-      def unapply(tree: g.DefDef): Option[(List[l.Modifier], l.CtorName, List[List[g.ValDef]], List[g.Tree])] = tree match {
+      def unapply(tree: g.DefDef)
+        : Option[(List[l.Modifier], l.CtorName, List[List[g.ValDef]], List[g.Tree])] = tree match {
         case l.CtorDef(false, mods, name, paramss, _, stats) => Some((mods, name, paramss, stats))
-        case _ => None
+        case _                                               => None
       }
     }
 
@@ -605,24 +645,40 @@ trait LogicalTrees {
 
     // ============ TEMPLATES ============
 
-    case class Template(early: List[g.Tree], parents: List[g.Tree], self: g.ValDef, stats: Option[List[g.Tree]]) extends Tree
+    case class Template(early: List[g.Tree],
+                        parents: List[g.Tree],
+                        self: g.ValDef,
+                        stats: Option[List[g.Tree]])
+        extends Tree
     object Template {
       def apply(tree0: g.Template, lowner: g.Tree): l.Template = {
         def containsSyntheticAnyRef(tree: g.Tree): Boolean = tree match {
-          case g.Select(scala: g.Ident, g.TypeName("AnyRef")) if scala.symbol == definitions.ScalaPackage => true
+          case g.Select(scala: g.Ident, g.TypeName("AnyRef"))
+              if scala.symbol == definitions.ScalaPackage =>
+            true
           case _ => false
         }
-        val tree = g.Template(tree0.parents.filterNot(containsSyntheticAnyRef), tree0.self, tree0.body)
-        def indexOfFirstCtor(trees: List[g.Tree]) = trees.indexWhere { case LowlevelCtor(_, _, _) => true; case _ => false }
+        val tree =
+          g.Template(tree0.parents.filterNot(containsSyntheticAnyRef), tree0.self, tree0.body)
+        def indexOfFirstCtor(trees: List[g.Tree]) = trees.indexWhere {
+          case LowlevelCtor(_, _, _) => true; case _ => false
+        }
         object LowlevelCtor {
-          def unapply(tree: g.Tree): Option[(List[List[g.ValDef]], List[g.Tree], List[List[g.Tree]])] = tree match {
-            case g.DefDef(_, nme.MIXIN_CONSTRUCTOR, _, _, _, SyntacticBlock(lvdefs :+ _)) =>
-              Some((Nil, lvdefs, Nil))
-            case g.DefDef(_, nme.CONSTRUCTOR, Nil, vparamss, _, SyntacticBlock(lvdefs :+ Applied(superCtor, _, superArgss) :+ _)) =>
-              Some((vparamss, lvdefs, superArgss))
-            case _ =>
-              None
-          }
+          def unapply(
+              tree: g.Tree): Option[(List[List[g.ValDef]], List[g.Tree], List[List[g.Tree]])] =
+            tree match {
+              case g.DefDef(_, nme.MIXIN_CONSTRUCTOR, _, _, _, SyntacticBlock(lvdefs :+ _)) =>
+                Some((Nil, lvdefs, Nil))
+              case g.DefDef(_,
+                            nme.CONSTRUCTOR,
+                            Nil,
+                            vparamss,
+                            _,
+                            SyntacticBlock(lvdefs :+ Applied(superCtor, _, superArgss) :+ _)) =>
+                Some((vparamss, lvdefs, superArgss))
+              case _ =>
+                None
+            }
         }
         val g.Template(parents, self, stats) = tree
         val lself = {
@@ -646,13 +702,16 @@ trait LogicalTrees {
           case _ => (Nil, Nil)
         }
         val edefs = evdefs ::: etdefs
-        val lparents = parents.zipWithIndex.map { case (parent, i) =>
-          val applied = dissectApplied(parent)
-          val syntacticArgss = applied.argss
-          val argss = if (syntacticArgss.isEmpty) List(List()) // todo dveim don't forget semanticArgss later
-                      else syntacticArgss
-          val lparent = argss.foldLeft(applied.callee)((curr, args) => g.Apply(curr, args))
-          lparent.set(new SupercallRole)
+        val lparents = parents.zipWithIndex.map {
+          case (parent, i) =>
+            val applied        = dissectApplied(parent)
+            val syntacticArgss = applied.argss
+            val argss =
+              if (syntacticArgss.isEmpty)
+                List(List()) // todo dveim don't forget semanticArgss later
+              else syntacticArgss
+            val lparent = argss.foldLeft(applied.callee)((curr, args) => g.Apply(curr, args))
+            lparent.set(new SupercallRole)
         }
         val lstats = Some(templateStats(userDefinedStats)) // TODO: somehow guess Some vs None
         l.Template(edefs, lparents, lself, lstats)
@@ -676,35 +735,39 @@ trait LogicalTrees {
     object SelfDef {
       def unapply(tree: g.ValDef): Option[(l.TermParamName, g.Tree)] = {
         if (!tree.is(SelfRole)) return None
-        val isAnonymous = tree.name == g.nme.WILDCARD || tree.name.startsWith(g.nme.FRESH_TERM_NAME_PREFIX)
+        val isAnonymous = tree.name == g.nme.WILDCARD || tree.name.startsWith(
+            g.nme.FRESH_TERM_NAME_PREFIX)
         val lvalue = if (isAnonymous) "this" else tree.displayName
-        val lname = if (isAnonymous) l.AnonymousName() else l.TermName(lvalue)
+        val lname  = if (isAnonymous) l.AnonymousName() else l.TermName(lvalue)
         Some((lname, tree.tpt))
       }
     }
 
     // ============ MODIFIERS ============
 
-    trait Modifier extends Tree
-    case class Private(within: g.Tree) extends Modifier // TODO: `within: l.QualifierName`
+    trait Modifier                       extends Tree
+    case class Private(within: g.Tree)   extends Modifier // TODO: `within: l.QualifierName`
     case class Protected(within: g.Tree) extends Modifier // TODO: `within: l.QualifierName`
-    case class Implicit() extends Modifier
-    case class Final() extends Modifier
-    case class Sealed() extends Modifier
-    case class Override() extends Modifier
-    case class Case() extends Modifier
-    case class Abstract() extends Modifier
-    case class Covariant() extends Modifier
-    case class Contravariant() extends Modifier
-    case class Lazy() extends Modifier
-    case class ValParam() extends Modifier
-    case class VarParam() extends Modifier
+    case class Implicit()                extends Modifier
+    case class Final()                   extends Modifier
+    case class Sealed()                  extends Modifier
+    case class Override()                extends Modifier
+    case class Case()                    extends Modifier
+    case class Abstract()                extends Modifier
+    case class Covariant()               extends Modifier
+    case class Contravariant()           extends Modifier
+    case class Lazy()                    extends Modifier
+    case class ValParam()                extends Modifier
+    case class VarParam()                extends Modifier
 
     object Modifiers {
       def apply(tree: g.MemberDef): List[l.Modifier] = {
         val mods @ g.Modifiers(flags, privateWithin, _) = tree.mods
 
-        case class ClassParameterInfo(param: g.ValDef, field: Option[g.ValDef], ctor: g.DefDef, cdef: g.ClassDef)
+        case class ClassParameterInfo(param: g.ValDef,
+                                      field: Option[g.ValDef],
+                                      ctor: g.DefDef,
+                                      cdef: g.ClassDef)
         val cpinfo: Option[ClassParameterInfo] = {
           val syntactically = {
             // TODO: We don't have tests for this, so for now I'll just comment this logic out.
@@ -726,14 +789,14 @@ trait LogicalTrees {
           }
           val semantically = {
             if (tree.symbol.owner.isPrimaryConstructor) {
-              val param = tree.require[g.ValDef]
-              val ctorSym = param.symbol.owner
-              val ctor = g.DefDef(ctorSym, g.EmptyTree)
-              val classSym = ctorSym.owner
-              val cdef = g.ClassDef(classSym, g.Template(Nil, g.noSelfType, Nil))
+              val param     = tree.require[g.ValDef]
+              val ctorSym   = param.symbol.owner
+              val ctor      = g.DefDef(ctorSym, g.EmptyTree)
+              val classSym  = ctorSym.owner
+              val cdef      = g.ClassDef(classSym, g.Template(Nil, g.noSelfType, Nil))
               val getterSym = classSym.info.member(param.name)
-              val fieldSym = getterSym.map(_.owner.info.member(getterSym.localName))
-              val field = if (fieldSym != g.NoSymbol) Some(g.ValDef(fieldSym)) else None
+              val fieldSym  = getterSym.map(_.owner.info.member(getterSym.localName))
+              val field     = if (fieldSym != g.NoSymbol) Some(g.ValDef(fieldSym)) else None
               Some(ClassParameterInfo(param, field, ctor, cdef))
             } else None
           }
@@ -774,20 +837,22 @@ trait LogicalTrees {
           if (mods.hasFlag(SEALED)) lmods += l.Sealed()
           if (mods.hasFlag(OVERRIDE)) lmods += l.Override()
           if (mods.hasFlag(CASE)) lmods += l.Case()
-          if (mods.hasFlag(ABSTRACT) && tree.isInstanceOf[g.ClassDef] && !mods.hasFlag(TRAIT)) lmods += l.Abstract()
+          if (mods.hasFlag(ABSTRACT) && tree.isInstanceOf[g.ClassDef] && !mods.hasFlag(TRAIT))
+            lmods += l.Abstract()
           if (mods.hasFlag(ABSOVERRIDE)) { lmods += l.Abstract(); lmods += l.Override() }
           if (mods.hasFlag(COVARIANT) && tree.isInstanceOf[g.TypeDef]) lmods += l.Covariant()
-          if (mods.hasFlag(CONTRAVARIANT) && tree.isInstanceOf[g.TypeDef]) lmods += l.Contravariant()
+          if (mods.hasFlag(CONTRAVARIANT) && tree.isInstanceOf[g.TypeDef])
+            lmods += l.Contravariant()
           if (mods.hasFlag(LAZY)) lmods += l.Lazy()
           lmods.toList
         }
 
         val lvalVarParamMods: List[l.Modifier] = {
-          val lmods = scala.collection.mutable.ListBuffer[l.Modifier]()
-          val field = cpinfo.flatMap(_.field)
+          val lmods            = scala.collection.mutable.ListBuffer[l.Modifier]()
+          val field            = cpinfo.flatMap(_.field)
           val isImmutableField = field.map(!_.mods.hasFlag(MUTABLE)).getOrElse(false)
-          val isMutableField = field.map(_.mods.hasFlag(MUTABLE)).getOrElse(false)
-          val inCaseClass = cpinfo.map(_.cdef).map(_.mods.hasFlag(CASE)).getOrElse(false)
+          val isMutableField   = field.map(_.mods.hasFlag(MUTABLE)).getOrElse(false)
+          val inCaseClass      = cpinfo.map(_.cdef).map(_.mods.hasFlag(CASE)).getOrElse(false)
           if (isMutableField) lmods += l.VarParam()
           if (isImmutableField && !inCaseClass) lmods += l.ValParam()
           lmods.toList
@@ -804,7 +869,7 @@ trait LogicalTrees {
 
     private def aggregateAnnotations(mdef: g.MemberDef): List[l.Annotation] = {
       val syntacticAnnots = mdef.mods.annotations
-      val semanticAnnots = mdef.symbol.annotations
+      val semanticAnnots  = mdef.symbol.annotations
       require(syntacticAnnots.isEmpty || semanticAnnots.isEmpty)
       if (syntacticAnnots.nonEmpty) syntacticAnnots.map(Annotation.apply)
       else semanticAnnots.map(Annotation.apply)
@@ -825,10 +890,11 @@ trait LogicalTrees {
     object Import {
       def unapply(tree: g.Import): Option[(g.Tree, List[l.ImportSelector])] = {
         val g.Import(expr, selectors) = tree
-        val lname = expr
+        val lname                     = expr
         val lselectors = selectors.map {
           case g.ImportSelector(name, _, rename, _) =>
-            l.ImportSelector(l.IndeterminateName(name.displayName), l.IndeterminateName(rename.displayName))
+            l.ImportSelector(l.IndeterminateName(name.displayName),
+                             l.IndeterminateName(rename.displayName))
         }
         Some(lname, lselectors)
       }
@@ -837,27 +903,33 @@ trait LogicalTrees {
     object CaseDef {
       def unapply(tree: g.CaseDef): Option[(g.Tree, Option[g.Tree], g.Tree)] = {
         val g.CaseDef(pat, guard, body) = tree
-        val lpat = pat.set(PatLoc)
-        val lguard = if (guard.nonEmpty) Some(guard) else None
+        val lpat                        = pat.set(PatLoc)
+        val lguard                      = if (guard.nonEmpty) Some(guard) else None
         Some((lpat, lguard, body))
       }
     }
 
     // ============ HELPERS ============
 
-    private def applyBounds(tparams: List[g.TypeDef], paramss: List[List[g.ValDef]]): List[g.TypeDef] = {
-      def tparam(targ: Tree): Option[g.TypeDef] = tparams.filter(tparam => {
-        if (tparam.symbol != g.NoSymbol) tparam.symbol == targ.symbol
-        else targ match { case g.Ident(name) => name == tparam.name; case _ => false }
-      }).headOption
+    private def applyBounds(tparams: List[g.TypeDef],
+                            paramss: List[List[g.ValDef]]): List[g.TypeDef] = {
+      def tparam(targ: Tree): Option[g.TypeDef] =
+        tparams
+          .filter(tparam => {
+            if (tparam.symbol != g.NoSymbol) tparam.symbol == targ.symbol
+            else targ match { case g.Ident(name) => name == tparam.name; case _ => false }
+          })
+          .headOption
 
       object ViewBound {
         def unapply(tree: g.ValDef): Option[(g.TypeDef, g.Tree)] = tree match {
           case g.ValDef(_, _, tpt @ g.TypeTree(), _) =>
             val tycon = if (tpt.tpe != null) tpt.tpe.typeSymbolDirect else g.NoSymbol
             val targs = if (tpt.tpe != null) tpt.tpe.typeArgs else Nil
-            val (fromTpe, toTpe) = targs match { case List(from, to) => (from, to); case _ => (g.NoType, g.NoType) }
-            val fromSym = fromTpe.typeSymbol
+            val (fromTpe, toTpe) = targs match {
+              case List(from, to) => (from, to); case _ => (g.NoType, g.NoType)
+            }
+            val fromSym      = fromTpe.typeSymbol
             val tyconMatches = tycon == g.definitions.FunctionClass(1)
             if (tyconMatches) tparam(Ident(fromSym)).map(tparam => (tparam, g.TypeTree(toTpe)))
             else None
@@ -865,9 +937,10 @@ trait LogicalTrees {
             val tyconMatches = tycon match {
               // NOTE: this doesn't handle every possible case (e.g. an Ident binding to renamed import),
               // but it should be good enough for 95% of the situations
-              case g.Select(pre, g.TermName("Function1")) => pre.symbol == g.definitions.ScalaPackage
+              case g.Select(pre, g.TermName("Function1")) =>
+                pre.symbol == g.definitions.ScalaPackage
               case tycon: g.RefTree => tycon.symbol == g.definitions.FunctionClass(1)
-              case _ => false
+              case _                => false
             }
             if (tyconMatches) tparam(from).map(tparam => (tparam, to))
             else None
@@ -881,7 +954,9 @@ trait LogicalTrees {
           case g.ValDef(_, _, tpt @ g.TypeTree(), _) =>
             val tycon = if (tpt.tpe != null) tpt.tpe.typeSymbolDirect else g.NoSymbol
             val targs = if (tpt.tpe != null) tpt.tpe.typeArgs else Nil
-            val targ = targs.map(_.typeSymbol) match { case List(sym) => sym; case _ => g.NoSymbol }
+            val targ = targs.map(_.typeSymbol) match {
+              case List(sym) => sym; case _ => g.NoSymbol
+            }
             tparam(Ident(targ)).map(tparam => (tparam, Ident(tycon)))
           case g.ValDef(_, _, g.AppliedTypeTree(tycon, targ :: Nil), _) =>
             tparam(targ).map(tparam => (tparam, tycon))
@@ -891,10 +966,12 @@ trait LogicalTrees {
       }
 
       val (explicitss, implicitss) = paramss.partition(_.exists(_.mods.hasFlag(IMPLICIT)))
-      val (bounds, implicits) = implicitss.flatten.partition(_.name.startsWith(nme.EVIDENCE_PARAM_PREFIX))
+      val (bounds, implicits) =
+        implicitss.flatten.partition(_.name.startsWith(nme.EVIDENCE_PARAM_PREFIX))
       tparams.map(tparam => {
         val vbounds = bounds.flatMap(ViewBound.unapply).filter(_._1.name == tparam.name).map(_._2)
-        val cbounds = bounds.flatMap(ContextBound.unapply).filter(_._1.name == tparam.name).map(_._2)
+        val cbounds =
+          bounds.flatMap(ContextBound.unapply).filter(_._1.name == tparam.name).map(_._2)
         tparam.set(TypeParamRole(vbounds, cbounds))
       })
     }
@@ -903,10 +980,10 @@ trait LogicalTrees {
       if (paramss.isEmpty) return Nil
       val init :+ last = paramss
       val hasImplicits = last.exists(_.mods.hasFlag(IMPLICIT))
-      val explicitss = if (hasImplicits) init else init :+ last
-      val implicits = if (hasImplicits) last else Nil
-      val limplicits = implicits.filter(!_.name.startsWith(nme.EVIDENCE_PARAM_PREFIX))
-      val lparamss = if (limplicits.nonEmpty) explicitss :+ limplicits else explicitss
+      val explicitss   = if (hasImplicits) init else init :+ last
+      val implicits    = if (hasImplicits) last else Nil
+      val limplicits   = implicits.filter(!_.name.startsWith(nme.EVIDENCE_PARAM_PREFIX))
+      val lparamss     = if (limplicits.nonEmpty) explicitss :+ limplicits else explicitss
       lparamss.map(_.map(_.set(TermParamRole)))
     }
 
@@ -918,17 +995,18 @@ trait LogicalTrees {
       // TODO: relevant synthetics are described in:
       // * subclasses of MultiEnsugarer: DefaultGetter, VanillaAccessor, AbstractAccessor, LazyAccessor
       // * ToMtree.mstats: PatDef, InlinableHoistedTemporaryVal
-      val lresult = mutable.ListBuffer[g.Tree]()
-      var i = 0
+      val lresult         = mutable.ListBuffer[g.Tree]()
+      var i               = 0
       var seenPrimaryCtor = false
       while (i < stats.length) {
         val stat = stats(i)
         i += 1
         stat match {
-          case g.DefDef(_, nme.CONSTRUCTOR, _, _, _, _) if !seenPrimaryCtor => seenPrimaryCtor = true // skip this
-          case g.DefDef(_, nme.MIXIN_CONSTRUCTOR, _, _, _, _) => // and this
+          case g.DefDef(_, nme.CONSTRUCTOR, _, _, _, _) if !seenPrimaryCtor =>
+            seenPrimaryCtor = true // skip this
+          case g.DefDef(_, nme.MIXIN_CONSTRUCTOR, _, _, _, _)         => // and this
           case g.ValDef(mods, _, _, _) if mods.hasFlag(PARAMACCESSOR) => // and this
-          case _ => lresult += stat
+          case _                                                      => lresult += stat
         }
       }
       lresult.toList
@@ -944,7 +1022,8 @@ trait LogicalTrees {
   sealed private trait Location {
     def test(tree: g.Tree): Boolean = {
       val actual = {
-        if (tree.isInstanceOf[g.PackageDef] || tree.metadata.contains("isLogicalToplevel")) ToplevelLoc
+        if (tree.isInstanceOf[g.PackageDef] || tree.metadata.contains("isLogicalToplevel"))
+          ToplevelLoc
         else if (tree.metadata.contains("isLogicalType")) TypeLoc
         else if (tree.isInstanceOf[g.CaseDef] || tree.metadata.contains("isLogicalPattern")) PatLoc
         else if (tree.metadata.contains("isLogicalParam")) ParamLoc
@@ -958,35 +1037,37 @@ trait LogicalTrees {
     }
     def mark[U <: g.Tree](tree: U): U = this match {
       case ToplevelLoc => tree.appendMetadata("isLogicalToplevel" -> true)
-      case StatLoc => tree.removeMetadata("isLogicalParam", "isLogicalSelf")
-      case ParamLoc => tree.appendMetadata("isLogicalParam" -> true)
-      case TermLoc => tree.removeMetadata("isLogicalType", "isLogicalPattern", "isLogicalSupercall")
-      case TypeLoc => tree.appendMetadata("isLogicalType" -> true)
-      case PatLoc => tree.appendMetadata("isLogicalPattern" -> true)
-      case TemplateLoc => require(tree.isInstanceOf[Template]); tree
+      case StatLoc     => tree.removeMetadata("isLogicalParam", "isLogicalSelf")
+      case ParamLoc    => tree.appendMetadata("isLogicalParam" -> true)
+      case TermLoc =>
+        tree.removeMetadata("isLogicalType", "isLogicalPattern", "isLogicalSupercall")
+      case TypeLoc      => tree.appendMetadata("isLogicalType" -> true)
+      case PatLoc       => tree.appendMetadata("isLogicalPattern" -> true)
+      case TemplateLoc  => require(tree.isInstanceOf[Template]); tree
       case SupercallLoc => tree.appendMetadata("isLogicalSupercall" -> true)
-      case SelfLoc => tree.appendMetadata("isLogicalSelf" -> true)
+      case SelfLoc      => tree.appendMetadata("isLogicalSelf" -> true)
     }
   }
 
-  @role private object ToplevelLoc extends Location with Role[g.Tree]
-  @role private object StatLoc extends Location with Role[g.Tree]
-  @role private object ParamLoc extends Location with Role[g.Tree]
-  @role private object TermLoc extends Location with Role[g.Tree]
-  @role private object TypeLoc extends Location with Role[g.Tree]
-  @role private object PatLoc extends Location with Role[g.Tree]
-  @role private object TemplateLoc extends Location with Role[g.Tree]
+  @role private object ToplevelLoc  extends Location with Role[g.Tree]
+  @role private object StatLoc      extends Location with Role[g.Tree]
+  @role private object ParamLoc     extends Location with Role[g.Tree]
+  @role private object TermLoc      extends Location with Role[g.Tree]
+  @role private object TypeLoc      extends Location with Role[g.Tree]
+  @role private object PatLoc       extends Location with Role[g.Tree]
+  @role private object TemplateLoc  extends Location with Role[g.Tree]
   @role private object SupercallLoc extends Location with Role[g.Tree]
-  @role private object SelfLoc extends Location with Role[g.Tree]
+  @role private object SelfLoc      extends Location with Role[g.Tree]
 
   // ============ ROLES (TYPEDEF) ============
 
   @role private object TypeMemberRole extends Role[g.TypeDef] {
-    def test(tree: g.TypeDef) = tree.is(StatLoc)
+    def test(tree: g.TypeDef)         = tree.is(StatLoc)
     def mark[U <: g.TypeDef](tree: U) = tree.set(StatLoc)
   }
 
-  @role private class TypeParamRole(lvbounds: List[g.Tree], lcbounds: List[g.Tree]) extends Role[g.TypeDef]
+  @role private class TypeParamRole(lvbounds: List[g.Tree], lcbounds: List[g.Tree])
+      extends Role[g.TypeDef]
   object TypeParamRole {
     def get(tree: g.TypeDef): Option[TypeParamRole] = {
       if (!tree.is(ParamLoc)) return None
@@ -1003,12 +1084,12 @@ trait LogicalTrees {
   // ============ ROLES (VALDEF) ============
 
   @role private object FieldRole extends Role[g.ValDef] {
-    def test(tree: g.ValDef) = tree.is(StatLoc)
+    def test(tree: g.ValDef)         = tree.is(StatLoc)
     def mark[U <: g.ValDef](tree: U) = tree.set(StatLoc)
   }
 
   @role private object TermParamRole extends Role[g.ValDef] {
-    def test(tree: g.ValDef) = tree.is(ParamLoc)
+    def test(tree: g.ValDef)         = tree.is(ParamLoc)
     def mark[U <: g.ValDef](tree: U) = tree.set(ParamLoc)
   }
 
@@ -1031,7 +1112,8 @@ trait LogicalTrees {
   }
 
   @role private object MethodRole extends ReadonlyRole[g.DefDef] {
-    def test(tree: g.DefDef) = tree.name != nme.CONSTRUCTOR && tree.rhs.nonEmpty && !tree.is(MacroRole)
+    def test(tree: g.DefDef) =
+      tree.name != nme.CONSTRUCTOR && tree.rhs.nonEmpty && !tree.is(MacroRole)
   }
 
   @role private object MacroRole extends ReadonlyRole[g.DefDef] {
@@ -1094,7 +1176,8 @@ trait LogicalTrees {
     def test(tree: g.PackageDef) = tree.name == nme.EMPTY_PACKAGE_NAME
   }
 
-  @role private class PackageObjectPackageRole(gmdef: g.ModuleDef) extends ReadonlyRole[g.PackageDef]
+  @role private class PackageObjectPackageRole(gmdef: g.ModuleDef)
+      extends ReadonlyRole[g.PackageDef]
   object PackageObjectPackageRole {
     def get(tree: g.PackageDef) = tree match {
       case g.PackageDef(pid, List(mdef: g.ModuleDef)) if mdef.name == nme.PACKAGE =>

--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/Metadata.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/Metadata.scala
@@ -1,8 +1,7 @@
 package org.scalameta.paradise
 package reflect
 
-trait Metadata {
-  self: ReflectToolkit =>
+trait Metadata { self: ReflectToolkit =>
 
   import global._
   import scala.reflect.ClassTag
@@ -17,16 +16,20 @@ trait Metadata {
   object Attachable {
     implicit object TreeAttachable extends Attachable[Tree] {
       def attachments(carrier: Tree): Attachments { type Pos = Position } = carrier.attachments
-      def updateAttachment[U: ClassTag](carrier: Tree, attachment: U): Unit = carrier.updateAttachment(attachment)
+      def updateAttachment[U: ClassTag](carrier: Tree, attachment: U): Unit =
+        carrier.updateAttachment(attachment)
     }
     implicit object SymbolAttachable extends Attachable[Symbol] {
       def attachments(carrier: Symbol): Attachments { type Pos = Position } = carrier.attachments
-      def updateAttachment[U: ClassTag](carrier: Symbol, attachment: U): Unit = carrier.updateAttachment(attachment)
+      def updateAttachment[U: ClassTag](carrier: Symbol, attachment: U): Unit =
+        carrier.updateAttachment(attachment)
     }
   }
   implicit class RichAttachable[T: Attachable](carrier: T) {
-    def attachments: Attachments { type Pos = Position } = implicitly[Attachable[T]].attachments(carrier)
-    def updateAttachment[U: ClassTag](attachment: U): Unit = implicitly[Attachable[T]].updateAttachment(carrier, attachment)
+    def attachments: Attachments { type Pos = Position } =
+      implicitly[Attachable[T]].attachments(carrier)
+    def updateAttachment[U: ClassTag](attachment: U): Unit =
+      implicitly[Attachable[T]].updateAttachment(carrier, attachment)
   }
 
   // NOTE: the mechanism of attachments is too low-level for our purposes
@@ -36,34 +39,45 @@ trait Metadata {
   // why Java's HashMap and not a native Scala Map? because prior to 2.11.2 attachments don't work  with subtyping and Map has a bunch of specific subclasses
   implicit class RichMetadataAttachable[T: Attachable](carrier: T) {
     def metadata: Metadata[T] = new Metadata(carrier)
-    def appendMetadata(kvps: (String, Any)*): T = { kvps.foreach(kvp => carrier.metadata += kvp); carrier }
-    def removeMetadata(keys: String*): T = { keys.foreach(key => carrier.metadata -= key); carrier }
+    def appendMetadata(kvps: (String, Any)*): T = {
+      kvps.foreach(kvp => carrier.metadata += kvp); carrier
+    }
+    def removeMetadata(keys: String*): T = {
+      keys.foreach(key => carrier.metadata -= key); carrier
+    }
     def hasMetadata(key: String): Boolean = metadata.get(key).isDefined
   }
 
   class Metadata[T: Attachable](carrier: T) {
     import scala.collection.JavaConversions._
-    def toMap: Map[String, Any] = carrier.attachments.get[java.util.HashMap[String, Any]].map(_.toMap).getOrElse(Map[String, Any]())
-    def toOption: Option[Map[String, Any]] = carrier.attachments.get[java.util.HashMap[String, Any]].map(_.toMap)
-    def transform(f: Map[String, Any] => Map[String, Any]): Unit = carrier.updateAttachment(new java.util.HashMap[String, Any](mapAsJavaMap(f(toMap))))
+    def toMap: Map[String, Any] =
+      carrier.attachments
+        .get[java.util.HashMap[String, Any]]
+        .map(_.toMap)
+        .getOrElse(Map[String, Any]())
+    def toOption: Option[Map[String, Any]] =
+      carrier.attachments.get[java.util.HashMap[String, Any]].map(_.toMap)
+    def transform(f: Map[String, Any] => Map[String, Any]): Unit =
+      carrier.updateAttachment(new java.util.HashMap[String, Any](mapAsJavaMap(f(toMap))))
     def contains(key: String): Boolean = toMap.contains(key)
-    def apply(key: String): Any = toMap(key)
-    def get(key: String): Option[Any] = toMap.get(key)
-    def getOrElse[T: ClassTag](key: String, value: => T): T = toMap.get(key).map(_.require[T]).getOrElse(value)
+    def apply(key: String): Any        = toMap(key)
+    def get(key: String): Option[Any]  = toMap.get(key)
+    def getOrElse[T: ClassTag](key: String, value: => T): T =
+      toMap.get(key).map(_.require[T]).getOrElse(value)
     def getOrElseUpdate[T: ClassTag](key: String, default: => T): T = {
       val valueopt = toMap.get(key).map(_.require[T])
-      val value = valueopt.getOrElse(default)
+      val value    = valueopt.getOrElse(default)
       if (valueopt.isEmpty) update(key, value)
       value
     }
     def update(key: String, value: Any): Unit = transform(_ + (key -> value))
-    def remove(key: String): Unit = transform(_ - key)
-    def +=(kvp: (String, Any)): Unit = update(kvp._1, kvp._2)
-    def ++=(other: Map[String, Any]): Unit = transform(_ ++ other)
-    def ++=(other: Metadata[T]): Unit = transform(_ ++ other.toMap)
-    def -=(key: String): Unit = remove(key)
-    def --=(other: List[String]): Unit = transform(_ -- other)
-    def --=(other: Metadata[T]): Unit = transform(_ -- other.toMap.keys)
-    override def toString = toMap.toString
+    def remove(key: String): Unit             = transform(_ - key)
+    def +=(kvp: (String, Any)): Unit          = update(kvp._1, kvp._2)
+    def ++=(other: Map[String, Any]): Unit    = transform(_ ++ other)
+    def ++=(other: Metadata[T]): Unit         = transform(_ ++ other.toMap)
+    def -=(key: String): Unit                 = remove(key)
+    def --=(other: List[String]): Unit        = transform(_ -- other)
+    def --=(other: Metadata[T]): Unit         = transform(_ -- other.toMap.keys)
+    override def toString                     = toMap.toString
   }
 }

--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/Mirrors.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/Mirrors.scala
@@ -1,8 +1,7 @@
 package org.scalameta.paradise
 package reflect
 
-trait Mirrors {
-  self: ReflectToolkit =>
+trait Mirrors { self: ReflectToolkit =>
 
   import global._
   import scala.language.reflectiveCalls

--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/Names.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/Names.scala
@@ -1,21 +1,20 @@
 package org.scalameta.paradise
 package reflect
 
-trait Names {
-  self: ReflectToolkit =>
+trait Names { self: ReflectToolkit =>
 
   import global._
 
   implicit class XtensionInlineManglingName(name: Name) {
     def inlineModuleName: TermName = TermName(name.toString.inlineModuleName)
-    def inlineImplName: TermName = TermName(name.toString.inlineImplName)
+    def inlineImplName: TermName   = TermName(name.toString.inlineImplName)
   }
 
   implicit class XtensionInlineManglingString(s: String) {
     def inlineModuleName: String = s.toString + "$inline"
-    def inlineImplName: String = s.toString
+    def inlineImplName: String   = s.toString
   }
 
-  lazy val InlinePrefixParameterName = TermName("prefix")
+  lazy val InlinePrefixParameterName  = TermName("prefix")
   lazy val InlineAnnotationMethodName = TermName("apply")
 }

--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/ReflectToolkit.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/ReflectToolkit.scala
@@ -5,16 +5,17 @@ import scala.language.implicitConversions
 import scala.tools.nsc.{Global => NscGlobal}
 import scala.tools.nsc.{Settings => NscSettings}
 
-trait ReflectToolkit extends Definitions
-                        with StdNames
-                        with TreeInfo
-                        with StdAttachments
-                        with Mirrors
-                        with Symbols
-                        with ReplIntegration
-                        with Names
-                        with Metadata
-                        with LogicalTrees {
+trait ReflectToolkit
+    extends Definitions
+    with StdNames
+    with TreeInfo
+    with StdAttachments
+    with Mirrors
+    with Symbols
+    with ReplIntegration
+    with Names
+    with Metadata
+    with LogicalTrees {
   val global: NscGlobal
   lazy val g: global.type = global
   object l extends LogicalTrees

--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/ReplIntegration.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/ReplIntegration.scala
@@ -3,32 +3,35 @@ package reflect
 
 import scala.tools.nsc.interpreter._
 
-trait ReplIntegration {
-  self: ReflectToolkit =>
+trait ReplIntegration { self: ReflectToolkit =>
 
   import global._
 
-  private def obtainField(cls: Class[_], name: String) = { val result = cls.getDeclaredField(name); result.setAccessible(true); result }
-  private lazy val f_intp = obtainField(classOf[ReplReporter], "intp")
+  private def obtainField(cls: Class[_], name: String) = {
+    val result = cls.getDeclaredField(name); result.setAccessible(true); result
+  }
+  private lazy val f_intp             = obtainField(classOf[ReplReporter], "intp")
   private lazy val f_executingRequest = obtainField(classOf[IMain], "executingRequest")
-  private lazy val f_handlers = obtainField(classOf[IMain#Request], "handlers")
-  private lazy val f_referencedNames = obtainField(classOf[IMain#Request], "referencedNames")
+  private lazy val f_handlers         = obtainField(classOf[IMain#Request], "handlers")
+  private lazy val f_referencedNames  = obtainField(classOf[IMain#Request], "referencedNames")
 
   // https://github.com/scalamacros/paradise/issues/19
   // REPL computes the list of defined members based on parsed code, not typechecked code
   // therefore we need to update its internal structures if that list changes
   // there's no API for that, but luckily it ended up being possible
   def tellReplAboutExpansion(sym: Symbol, companion: Symbol, expanded: List[Tree]): Unit = {
-    if (global.reporter.isInstanceOf[ReplReporter] && sym.owner.name.toString == nme.INTERPRETER_IMPORT_WRAPPER.toString) {
+    if (global.reporter
+          .isInstanceOf[ReplReporter] && sym.owner.name.toString == nme.INTERPRETER_IMPORT_WRAPPER.toString) {
       val intp = f_intp.get(global.reporter).asInstanceOf[IMain]
-      val req = f_executingRequest.get(intp).asInstanceOf[intp.Request]
+      val req  = f_executingRequest.get(intp).asInstanceOf[intp.Request]
       import intp._
       import memberHandlers._
       val handlers1 = req.handlers.flatMap {
         // TODO: I challenge you to write this without a cast :)
-        case dh: MemberDefHandler if dh.member.name == sym.name => expanded map (memberHandlers chooseHandler _.asInstanceOf[intp.global.Tree])
+        case dh: MemberDefHandler if dh.member.name == sym.name =>
+          expanded map (memberHandlers chooseHandler _.asInstanceOf[intp.global.Tree])
         case dh: MemberDefHandler if dh.member.name == companion.name => Nil
-        case h => List(h)
+        case h                                                        => List(h)
       }
       val referencedNames1 = handlers1 flatMap (_.referencedNames)
       f_handlers.set(req, handlers1)

--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/StdAttachments.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/StdAttachments.scala
@@ -1,21 +1,24 @@
 package org.scalameta.paradise
 package reflect
 
-trait StdAttachments {
-  self: ReflectToolkit =>
+trait StdAttachments { self: ReflectToolkit =>
 
   import global._
   import scala.collection.{immutable, mutable}
 
   case object WeakSymbolAttachment
-  def markWeak(sym: Symbol) = if (sym != null && sym != NoSymbol) sym.updateAttachment(WeakSymbolAttachment) else sym
-  def unmarkWeak(sym: Symbol) = if (sym != null && sym != NoSymbol) sym.removeAttachment[WeakSymbolAttachment.type] else sym
-  def isWeak(sym: Symbol) = sym == null || sym == NoSymbol || sym.attachments.get[WeakSymbolAttachment.type].isDefined
+  def markWeak(sym: Symbol) =
+    if (sym != null && sym != NoSymbol) sym.updateAttachment(WeakSymbolAttachment) else sym
+  def unmarkWeak(sym: Symbol) =
+    if (sym != null && sym != NoSymbol) sym.removeAttachment[WeakSymbolAttachment.type] else sym
+  def isWeak(sym: Symbol) =
+    sym == null || sym == NoSymbol || sym.attachments.get[WeakSymbolAttachment.type].isDefined
 
   case class SymbolCompleterAttachment(info: Type)
   def backupCompleter(sym: Symbol): Symbol = {
     if (sym != null && sym != NoSymbol) {
-      assert(sym.rawInfo.isInstanceOf[LazyType], s"${sym.accurateKindString} ${sym.rawname}#${sym.id} with ${sym.rawInfo.kind}")
+      assert(sym.rawInfo.isInstanceOf[LazyType],
+             s"${sym.accurateKindString} ${sym.rawname}#${sym.id} with ${sym.rawInfo.kind}")
       sym.updateAttachment(SymbolCompleterAttachment(sym.rawInfo))
     } else sym
   }
@@ -29,8 +32,17 @@ trait StdAttachments {
 
   // here we should really store and retrieve duplicates of trees in order to avoid leakage through tree attributes
   case class SymbolSourceAttachment(source: Tree)
-  def attachSource(sym: Symbol, tree: Tree): Symbol = if (sym != null && sym != NoSymbol) sym.updateAttachment(SymbolSourceAttachment(duplicateAndKeepPositions(tree))) else sym
-  def attachedSource(sym: Symbol): Tree = if (sym != null && sym != NoSymbol) sym.attachments.get[SymbolSourceAttachment].map(att => duplicateAndKeepPositions(att.source)).getOrElse(EmptyTree) else EmptyTree
+  def attachSource(sym: Symbol, tree: Tree): Symbol =
+    if (sym != null && sym != NoSymbol)
+      sym.updateAttachment(SymbolSourceAttachment(duplicateAndKeepPositions(tree)))
+    else sym
+  def attachedSource(sym: Symbol): Tree =
+    if (sym != null && sym != NoSymbol)
+      sym.attachments
+        .get[SymbolSourceAttachment]
+        .map(att => duplicateAndKeepPositions(att.source))
+        .getOrElse(EmptyTree)
+    else EmptyTree
 
   // unfortunately we cannot duplicate here, because that would dissociate the symbol from its derived symbols
   // that's because attachExpansion(tree) happens prior to enterSym(tree), so if we duplicate the assigned symbol never makes it into the att
@@ -40,23 +52,38 @@ trait StdAttachments {
   // TODO: should be a better solution
   case class SymbolExpansionAttachment(expansion: List[Tree])
   def hasAttachedExpansion(sym: Symbol) = sym.attachments.get[SymbolExpansionAttachment].isDefined
-  def attachExpansion(sym: Symbol, trees: List[Tree]): Symbol = if (sym != null && sym != NoSymbol) sym.updateAttachment(SymbolExpansionAttachment(trees/*.map(tree => duplicateAndKeepPositions(tree))*/)) else sym
-  def attachedExpansion(sym: Symbol): Option[List[Tree]] = if (sym != null && sym != NoSymbol) sym.attachments.get[SymbolExpansionAttachment].map(_.expansion/*.map(tree => duplicateAndKeepPositions(tree))*/) else None
+  def attachExpansion(sym: Symbol, trees: List[Tree]): Symbol =
+    if (sym != null && sym != NoSymbol)
+      sym.updateAttachment(
+        SymbolExpansionAttachment(trees /*.map(tree => duplicateAndKeepPositions(tree))*/ ))
+    else sym
+  def attachedExpansion(sym: Symbol): Option[List[Tree]] =
+    if (sym != null && sym != NoSymbol)
+      sym.attachments
+        .get[SymbolExpansionAttachment]
+        .map(_.expansion /*.map(tree => duplicateAndKeepPositions(tree))*/ )
+    else None
 
   import SymbolExpansionStatus._
-  private def checkExpansionStatus(sym: Symbol, p: SymbolExpansionStatus => Boolean) = sym.attachments.get[SymbolExpansionStatus].map(p).getOrElse(false)
+  private def checkExpansionStatus(sym: Symbol, p: SymbolExpansionStatus => Boolean) =
+    sym.attachments.get[SymbolExpansionStatus].map(p).getOrElse(false)
   def isMaybeExpandee(sym: Symbol): Boolean = checkExpansionStatus(sym, _.isUnknown)
-  def isExpanded(sym: Symbol): Boolean = checkExpansionStatus(sym, _.isExpanded)
+  def isExpanded(sym: Symbol): Boolean      = checkExpansionStatus(sym, _.isExpanded)
   def isNotExpandable(sym: Symbol): Boolean = checkExpansionStatus(sym, _.isNotExpandable)
-  def markMaybeExpandee(sym: Symbol): Symbol = if (sym != null && sym != NoSymbol) sym.updateAttachment(Unknown) else sym
-  def markExpanded(sym: Symbol): Symbol = if (sym != null && sym != NoSymbol) sym.updateAttachment(Expanded) else sym
-  def markNotExpandable(sym: Symbol): Symbol = if (sym != null && sym != NoSymbol) sym.updateAttachment(NotExpandable) else sym
-  def unmarkExpanded(sym: Symbol): Symbol = if (sym != null && sym != NoSymbol) sym.removeAttachment[SymbolExpansionStatus] else sym
+  def markMaybeExpandee(sym: Symbol): Symbol =
+    if (sym != null && sym != NoSymbol) sym.updateAttachment(Unknown) else sym
+  def markExpanded(sym: Symbol): Symbol =
+    if (sym != null && sym != NoSymbol) sym.updateAttachment(Expanded) else sym
+  def markNotExpandable(sym: Symbol): Symbol =
+    if (sym != null && sym != NoSymbol) sym.updateAttachment(NotExpandable) else sym
+  def unmarkExpanded(sym: Symbol): Symbol =
+    if (sym != null && sym != NoSymbol) sym.removeAttachment[SymbolExpansionStatus] else sym
 
   case class CacheAttachment(cache: mutable.Map[String, Any])
   implicit class RichTree(tree: Tree) {
     def cached[T](key: String, op: => T): T = {
-      val cache = tree.attachments.get[CacheAttachment].map(_.cache).getOrElse(mutable.Map[String, Any]())
+      val cache =
+        tree.attachments.get[CacheAttachment].map(_.cache).getOrElse(mutable.Map[String, Any]())
       val result = cache.getOrElseUpdate(key, op).asInstanceOf[T]
       tree.updateAttachment(CacheAttachment(cache))
       result
@@ -65,12 +92,12 @@ trait StdAttachments {
 }
 
 class SymbolExpansionStatus private (val value: Int) extends AnyVal {
-  def isUnknown = this == SymbolExpansionStatus.Unknown
-  def isExpanded = this == SymbolExpansionStatus.Expanded
+  def isUnknown       = this == SymbolExpansionStatus.Unknown
+  def isExpanded      = this == SymbolExpansionStatus.Expanded
   def isNotExpandable = this == SymbolExpansionStatus.NotExpandable
 }
 object SymbolExpansionStatus {
-  val Unknown = new SymbolExpansionStatus(0)
-  val Expanded = new SymbolExpansionStatus(1)
+  val Unknown       = new SymbolExpansionStatus(0)
+  val Expanded      = new SymbolExpansionStatus(1)
   val NotExpandable = new SymbolExpansionStatus(2)
 }

--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/StdNames.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/StdNames.scala
@@ -1,13 +1,12 @@
 package org.scalameta.paradise
 package reflect
 
-trait StdNames {
-  self: ReflectToolkit =>
+trait StdNames { self: ReflectToolkit =>
 
   import global._
 
   implicit class ParadiseNme(nme: global.nme.type) {
-    val annottees          = TermName("annottees")
-    val macroTransform     = TermName("macroTransform")
+    val annottees      = TermName("annottees")
+    val macroTransform = TermName("macroTransform")
   }
 }

--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/Symbols.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/Symbols.scala
@@ -1,8 +1,7 @@
 package org.scalameta.paradise
 package reflect
 
-trait Symbols {
-  self: ReflectToolkit =>
+trait Symbols { self: ReflectToolkit =>
 
   import global._
   import scala.reflect.internal.Flags._
@@ -18,9 +17,13 @@ trait Symbols {
     def isNewMacroAnnotation = {
       sym.isClass && {
         val MetaInlineClass = rootMirror.getClassIfDefined("scala.meta.internal.inline.inline")
-        val annMethod = sym.info.decl(InlineAnnotationMethodName)
-        val annImplMethod = sym.owner.info.decl(sym.name.inlineModuleName).info.decl(InlineAnnotationMethodName.inlineImplName)
-        annMethod != NoSymbol && annMethod.initialize.annotations.exists(_.tpe.typeSymbol == MetaInlineClass) && annImplMethod.exists
+        val annMethod       = sym.info.decl(InlineAnnotationMethodName)
+        val annImplMethod = sym.owner.info
+          .decl(sym.name.inlineModuleName)
+          .info
+          .decl(InlineAnnotationMethodName.inlineImplName)
+        annMethod != NoSymbol && annMethod.initialize.annotations
+          .exists(_.tpe.typeSymbol == MetaInlineClass) && annImplMethod.exists
       }
     }
     def isMacroAnnotation = isOldMacroAnnotation || isNewMacroAnnotation

--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/TreeInfo.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/TreeInfo.scala
@@ -1,8 +1,7 @@
 package org.scalameta.paradise
 package reflect
 
-trait TreeInfo {
-  self: ReflectToolkit =>
+trait TreeInfo { self: ReflectToolkit =>
 
   import global._
   import definitions._
@@ -10,9 +9,10 @@ trait TreeInfo {
   import build.{SyntacticClassDef, SyntacticTraitDef}
 
   implicit class ParadiseTreeInfo(treeInfo: global.treeInfo.type) {
-    def primaryConstructorArity(tree: ClassDef): Int = treeInfo.firstConstructor(tree.impl.body) match {
-      case DefDef(_, _, _, params :: _, _, _) => params.length
-    }
+    def primaryConstructorArity(tree: ClassDef): Int =
+      treeInfo.firstConstructor(tree.impl.body) match {
+        case DefDef(_, _, _, params :: _, _, _) => params.length
+      }
 
     def anyConstructorHasDefault(tree: ClassDef): Boolean = tree.impl.body exists {
       case DefDef(_, nme.CONSTRUCTOR, _, paramss, _, _) => mexists(paramss)(_.mods.hasDefault)
@@ -20,14 +20,14 @@ trait TreeInfo {
     }
 
     def isOldMacroAnnotation(tree: ClassDef): Boolean = {
-      val clazz = tree.symbol
-      def isAnnotation = clazz isNonBottomSubClass AnnotationClass
+      val clazz                   = tree.symbol
+      def isAnnotation            = clazz isNonBottomSubClass AnnotationClass
       def hasMacroTransformMethod = clazz.info.member(nme.macroTransform) != NoSymbol
       clazz != null && isAnnotation && hasMacroTransformMethod
     }
 
     def isNewMacroAnnotation(tree: ClassDef): Boolean = {
-      val clazz = tree.symbol
+      val clazz        = tree.symbol
       def isAnnotation = clazz isNonBottomSubClass AnnotationClass
       def hasInlineApplyMethod = {
         val apply = clazz.info.member(nme.apply)
@@ -40,27 +40,68 @@ trait TreeInfo {
     // TODO: no immediate idea how to write this in a sane way
     def getAnnotationZippers(tree: Tree): List[AnnotationZipper] = {
       def loop[T <: Tree](tree: T, deep: Boolean): List[AnnotationZipper] = tree match {
-        case SyntacticClassDef(mods, name, tparams, constrMods, vparamss, earlyDefs, parents, selfdef, body) =>
+        case SyntacticClassDef(mods,
+                               name,
+                               tparams,
+                               constrMods,
+                               vparamss,
+                               earlyDefs,
+                               parents,
+                               selfdef,
+                               body) =>
           val cdef = tree.asInstanceOf[ClassDef]
           val czippers = mods.annotations.map(ann => {
             val mods1 = mods.mapAnnotations(_ diff List(ann))
-            val annottee = atPos(tree.pos)(PatchedSyntacticClassDef(mods1, name, tparams, constrMods, vparamss, earlyDefs, parents, selfdef, body))
+            val annottee = atPos(tree.pos)(
+              PatchedSyntacticClassDef(mods1,
+                                       name,
+                                       tparams,
+                                       constrMods,
+                                       vparamss,
+                                       earlyDefs,
+                                       parents,
+                                       selfdef,
+                                       body))
             AnnotationZipper(ann, annottee, annottee)
           })
           if (!deep) czippers
           else {
             val tzippers = for {
-              tparam <- tparams
+              tparam                                     <- tparams
               AnnotationZipper(ann, tparam1: TypeDef, _) <- loop(tparam, deep = false)
               tparams1 = tparams.updated(tparams.indexOf(tparam), tparam1)
-            } yield AnnotationZipper(ann, tparam1, atPos(tree.pos)(PatchedSyntacticClassDef(mods, name, tparams1, constrMods, vparamss, earlyDefs, parents, selfdef, body)))
+            } yield
+              AnnotationZipper(ann,
+                               tparam1,
+                               atPos(tree.pos)(
+                                 PatchedSyntacticClassDef(mods,
+                                                          name,
+                                                          tparams1,
+                                                          constrMods,
+                                                          vparamss,
+                                                          earlyDefs,
+                                                          parents,
+                                                          selfdef,
+                                                          body)))
             val vzippers = for {
-              vparams <- vparamss
-              vparam <- vparams
+              vparams                                   <- vparamss
+              vparam                                    <- vparams
               AnnotationZipper(ann, vparam1: ValDef, _) <- loop(vparam, deep = false)
-              vparams1 = vparams.updated(vparams.indexOf(vparam), vparam1)
+              vparams1  = vparams.updated(vparams.indexOf(vparam), vparam1)
               vparamss1 = vparamss.updated(vparamss.indexOf(vparams), vparams1)
-            } yield AnnotationZipper(ann, vparam1, atPos(tree.pos)(PatchedSyntacticClassDef(mods, name, tparams, constrMods, vparamss1, earlyDefs, parents, selfdef, body)))
+            } yield
+              AnnotationZipper(ann,
+                               vparam1,
+                               atPos(tree.pos)(
+                                 PatchedSyntacticClassDef(mods,
+                                                          name,
+                                                          tparams,
+                                                          constrMods,
+                                                          vparamss1,
+                                                          earlyDefs,
+                                                          parents,
+                                                          selfdef,
+                                                          body)))
             czippers ++ tzippers ++ vzippers
           }
         case SyntacticTraitDef(mods, name, tparams, earlyDefs, parents, selfdef, body) =>
@@ -72,7 +113,7 @@ trait TreeInfo {
           if (!deep) czippers
           else {
             val tzippers = for {
-              tparam <- tparams
+              tparam                                     <- tparams
               AnnotationZipper(ann, tparam1: TypeDef, _) <- loop(tparam, deep = false)
               tparams1 = tparams.updated(tparams.indexOf(tparam), tparam1)
             } yield AnnotationZipper(ann, tparam1, atPos(tree.pos)(tdef.copy(tparams = tparams1)))
@@ -91,17 +132,18 @@ trait TreeInfo {
           if (!deep) dzippers
           else {
             val tzippers = for {
-              tparam <- tparams
+              tparam                                     <- tparams
               AnnotationZipper(ann, tparam1: TypeDef, _) <- loop(tparam, deep = false)
               tparams1 = tparams.updated(tparams.indexOf(tparam), tparam1)
             } yield AnnotationZipper(ann, tparam1, atPos(tree.pos)(ddef.copy(tparams = tparams1)))
             val vzippers = for {
-              vparams <- vparamss
-              vparam <- vparams
+              vparams                                   <- vparamss
+              vparam                                    <- vparams
               AnnotationZipper(ann, vparam1: ValDef, _) <- loop(vparam, deep = false)
-              vparams1 = vparams.updated(vparams.indexOf(vparam), vparam1)
+              vparams1  = vparams.updated(vparams.indexOf(vparam), vparam1)
               vparamss1 = vparamss.updated(vparamss.indexOf(vparams), vparams1)
-            } yield AnnotationZipper(ann, vparam1, atPos(tree.pos)(ddef.copy(vparamss = vparamss1)))
+            } yield
+              AnnotationZipper(ann, vparam1, atPos(tree.pos)(ddef.copy(vparamss = vparamss1)))
             dzippers ++ tzippers ++ vzippers
           }
         case vdef @ ValDef(mods, _, _, _) =>
@@ -117,7 +159,7 @@ trait TreeInfo {
           if (!deep) tzippers
           else {
             val ttzippers = for {
-              tparam <- tparams
+              tparam                                     <- tparams
               AnnotationZipper(ann, tparam1: TypeDef, _) <- loop(tparam, deep = false)
               tparams1 = tparams.updated(tparams.indexOf(tparam), tparam1)
             } yield AnnotationZipper(ann, tparam1, atPos(tree.pos)(tdef.copy(tparams = tparams1)))
@@ -130,11 +172,25 @@ trait TreeInfo {
     }
 
     private object PatchedSyntacticClassDef {
-      def apply(mods: Modifiers, name: TypeName, tparams: List[Tree],
-                constrMods: Modifiers, vparamss: List[List[Tree]],
-                earlyDefs: List[Tree], parents: List[Tree], selfType: Tree, body: List[Tree]): ClassDef = {
+      def apply(mods: Modifiers,
+                name: TypeName,
+                tparams: List[Tree],
+                constrMods: Modifiers,
+                vparamss: List[List[Tree]],
+                earlyDefs: List[Tree],
+                parents: List[Tree],
+                selfType: Tree,
+                body: List[Tree]): ClassDef = {
         // NOTE: works around SI-8771 and hopefully fixes https://github.com/scalamacros/paradise/issues/53 for good
-        SyntacticClassDef(mods, name, tparams, constrMods, vparamss.map(_.map(_.duplicate)), earlyDefs, parents, selfType, body)
+        SyntacticClassDef(mods,
+                          name,
+                          tparams,
+                          constrMods,
+                          vparamss.map(_.map(_.duplicate)),
+                          earlyDefs,
+                          parents,
+                          selfType,
+                          body)
       }
     }
   }

--- a/plugin/src/main/scala/org/scalameta/paradise/typechecker/Analyzer.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/typechecker/Analyzer.scala
@@ -16,7 +16,9 @@ trait ParadiseAnalyzer extends NscAnalyzer with ReflectToolkit {
     override def typedDefDef(ddef: DefDef): DefDef = {
       val ddef1 = super.typedDefDef(ddef)
       if (ddef1.symbol.hasAnnotation(MetaInlineClass) && !ddef1.symbol.owner.isNewMacroAnnotation) {
-        typer.context.error(ddef1.pos, "implementation restriction: inline methods can only be used to define new-style macro annotations")
+        typer.context.error(
+          ddef1.pos,
+          "implementation restriction: inline methods can only be used to define new-style macro annotations")
       }
       ddef1
     }

--- a/plugin/src/main/scala/org/scalameta/paradise/typechecker/Compilers.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/typechecker/Compilers.scala
@@ -1,8 +1,7 @@
 package org.scalameta.paradise
 package typechecker
 
-trait Compilers {
-  self: AnalyzerPlugins =>
+trait Compilers { self: AnalyzerPlugins =>
 
   import global._
   import analyzer._
@@ -16,8 +15,13 @@ trait Compilers {
     import errorGen._
 
     private def checkClass(clazz: Symbol): Unit = {
-      clazz.addAnnotation(AnnotationInfo(CompileTimeOnlyAttr.tpe, List(Literal(Constant(MacroAnnotationNotExpandedMessage)) setType StringClass.tpe), Nil))
-      if (!(clazz isNonBottomSubClass StaticAnnotationClass)) MacroAnnotationMustBeStaticError(clazz)
+      clazz.addAnnotation(
+        AnnotationInfo(
+          CompileTimeOnlyAttr.tpe,
+          List(Literal(Constant(MacroAnnotationNotExpandedMessage)) setType StringClass.tpe),
+          Nil))
+      if (!(clazz isNonBottomSubClass StaticAnnotationClass))
+        MacroAnnotationMustBeStaticError(clazz)
       // TODO: revisit the decision about @Inherited
       if (clazz.getAnnotation(InheritedAttr).nonEmpty) MacroAnnotationCannotBeInheritedError(clazz)
       if (!clazz.isStatic) MacroAnnotationCannotBeMemberError(clazz)
@@ -30,9 +34,11 @@ trait Compilers {
         clazz.setFlag(MACRO)
 
         val macroTransform = clazz.info.member(nme.macroTransform)
-        def flavorOk = macroTransform.isMacro
-        def paramssOk = mmap(macroTransform.paramss)(p => (p.name, p.info)) == List(List((nme.annottees, scalaRepeatedType(AnyTpe))))
-        def tparamsOk = macroTransform.typeParams.isEmpty
+        def flavorOk       = macroTransform.isMacro
+        def paramssOk =
+          mmap(macroTransform.paramss)(p => (p.name, p.info)) == List(
+            List((nme.annottees, scalaRepeatedType(AnyTpe))))
+        def tparamsOk    = macroTransform.typeParams.isEmpty
         def everythingOk = flavorOk && paramssOk && tparamsOk
         if (!everythingOk) OldMacroAnnotationShapeError(clazz)
       }
@@ -45,10 +51,10 @@ trait Compilers {
         checkClass(clazz)
         // NOTE: don't set the MACRO flag to distinguish from old macro annotations
 
-        val apply = clazz.info.member(nme.apply)
-        def paramssOk = mmap(apply.paramss)(_.info) == List(List(AnyTpe))
-        def retOk = apply.info.finalResultType == AnyTpe
-        def tparamsOk = clazz.typeParams.isEmpty
+        val apply        = clazz.info.member(nme.apply)
+        def paramssOk    = mmap(apply.paramss)(_.info) == List(List(AnyTpe))
+        def retOk        = apply.info.finalResultType == AnyTpe
+        def tparamsOk    = clazz.typeParams.isEmpty
         def everythingOk = paramssOk && retOk && tparamsOk
         if (!everythingOk) NewMacroAnnotationShapeError(clazz)
       }

--- a/plugin/src/main/scala/org/scalameta/paradise/typechecker/Errors.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/typechecker/Errors.scala
@@ -1,8 +1,7 @@
 package org.scalameta.paradise
 package typechecker
 
-trait Errors {
-  self: AnalyzerPlugins =>
+trait Errors { self: AnalyzerPlugins =>
 
   import global._
   import analyzer._
@@ -23,15 +22,19 @@ trait Errors {
             def showTparam(tparam: Symbol) =
               tparam.typeSignature match {
                 case tpe @ TypeBounds(_, _) => s"${tparam.name}$tpe"
-                case _ => tparam.name
+                case _                      => tparam.name
               }
-            def showTparams(tparams: List[Symbol]) = "[" + (tparams map showTparam mkString ", ") + "]"
+            def showTparams(tparams: List[Symbol]) =
+              "[" + (tparams map showTparam mkString ", ") + "]"
             result += showTparams(meth.typeParams)
           }
           if (meth.paramss.nonEmpty) {
             def showParam(param: Symbol) = s"${param.name}: ${param.typeSignature}"
             def showParams(params: List[Symbol]) = {
-              val s_mods = if (params.nonEmpty && params(0).hasFlag(scala.reflect.internal.Flags.IMPLICIT)) "implicit " else ""
+              val s_mods =
+                if (params.nonEmpty && params(0).hasFlag(scala.reflect.internal.Flags.IMPLICIT))
+                  "implicit "
+                else ""
               val s_params = params map showParam mkString ", "
               "(" + s_mods + s_params + ")"
             }
@@ -51,7 +54,8 @@ trait Errors {
     }
 
     protected def MacroAnnotationShapeError(clazz: Symbol, expected: String, actual: String) = {
-      issueSymbolTypeError(clazz, s"""
+      issueSymbolTypeError(clazz,
+                           s"""
         |macro annotation has wrong shape:
         |  required: $expected
         |  found   : $actual
@@ -59,7 +63,8 @@ trait Errors {
     }
 
     def MacroAnnotationMustBeStaticError(clazz: Symbol) =
-      issueSymbolTypeError(clazz, s"macro annotation must extend scala.annotation.StaticAnnotation")
+      issueSymbolTypeError(clazz,
+                           s"macro annotation must extend scala.annotation.StaticAnnotation")
 
     def MacroAnnotationCannotBeInheritedError(clazz: Symbol) =
       issueSymbolTypeError(clazz, s"macro annotation cannot be @Inherited")
@@ -69,41 +74,47 @@ trait Errors {
 
     def MacroAnnotationNotExpandedMessage = {
       "macro annotation could not be expanded " +
-      "(the most common reason for that is that you need to enable the macro paradise plugin; " +
-      "another possibility is that you try to use macro annotation in the same compilation run that defines it)"
+        "(the most common reason for that is that you need to enable the macro paradise plugin; " +
+        "another possibility is that you try to use macro annotation in the same compilation run that defines it)"
     }
 
     def MacroAnnotationOnlyDefinitionError(ann: Tree) =
       issueNormalTypeError(ann, "macro annotations can only be put on definitions")
 
     def MacroAnnotationTopLevelClassWithCompanionBadExpansion(ann: Tree) =
-      issueNormalTypeError(ann, "top-level class with companion can only expand into a block consisting in eponymous companions")
+      issueNormalTypeError(
+        ann,
+        "top-level class with companion can only expand into a block consisting in eponymous companions")
 
     def MacroAnnotationTopLevelClassWithoutCompanionBadExpansion(ann: Tree) =
-      issueNormalTypeError(ann, "top-level class without companion can only expand either into an eponymous class or into a block consisting in eponymous companions")
+      issueNormalTypeError(
+        ann,
+        "top-level class without companion can only expand either into an eponymous class or into a block consisting in eponymous companions")
 
     def MacroAnnotationTopLevelModuleBadExpansion(ann: Tree) =
       issueNormalTypeError(ann, "top-level object can only expand into an eponymous object")
 
     def MultipleParametersImplicitClassError(tree: Tree) =
-      issueNormalTypeError(tree, "implicit classes must accept exactly one primary constructor parameter")
+      issueNormalTypeError(
+        tree,
+        "implicit classes must accept exactly one primary constructor parameter")
   }
 
   trait OldErrorGen extends CommonErrorGen {
     def OldMacroAnnotationShapeError(clazz: Symbol) = {
-      val meth = clazz.info.member(nme.macroTransform)
+      val meth     = clazz.info.member(nme.macroTransform)
       val expected = "def macroTransform(annottees: Any*): Any = macro ..."
-      val actual = meth.actualSignature
+      val actual   = meth.actualSignature
       MacroAnnotationShapeError(clazz, expected, actual)
     }
   }
 
   trait NewErrorGen extends CommonErrorGen {
     def NewMacroAnnotationShapeError(clazz: Symbol) = {
-      val meth = clazz.info.member(nme.apply)
-      val param = meth.paramss match { case List(List(p)) => p.name.toString; case _ => "defn" }
+      val meth     = clazz.info.member(nme.apply)
+      val param    = meth.paramss match { case List(List(p)) => p.name.toString; case _ => "defn" }
       val expected = s"inline def apply($param: Any): Any = meta { ... }"
-      val actual = meth.actualSignature.replace(": Nothing", "")
+      val actual   = meth.actualSignature.replace(": Nothing", "")
       MacroAnnotationShapeError(clazz, expected, actual)
     }
   }

--- a/plugin/src/main/scala/org/scalameta/paradise/typechecker/HijackAnalyzer.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/typechecker/HijackAnalyzer.scala
@@ -7,28 +7,34 @@ import scala.tools.nsc.plugins.{Plugin => NscPlugin, PluginComponent => NscPlugi
 import scala.collection.mutable
 import scala.tools.nsc.typechecker.ParadiseAnalyzer
 import scala.tools.nsc.interpreter.{ReplGlobal => NscReplGlobal}
-import scala.tools.nsc.interactive.{Global => NscInteractiveGlobal, InteractiveAnalyzer => NscInteractiveAnalyzer}
+import scala.tools.nsc.interactive.{
+  Global => NscInteractiveGlobal,
+  InteractiveAnalyzer => NscInteractiveAnalyzer
+}
 
-trait HijackAnalyzer {
-  self: NscPlugin =>
+trait HijackAnalyzer { self: NscPlugin =>
 
   def hijackAnalyzer(): global.analyzer.type = {
     // NOTE: need to hijack the right `analyzer` field - it's different for batch compilers and repl compilers
-    val isRepl = global.isInstanceOf[NscReplGlobal]
+    val isRepl        = global.isInstanceOf[NscReplGlobal]
     val isInteractive = global.isInstanceOf[NscInteractiveGlobal]
     val newAnalyzer = {
       if (isInteractive) {
         new {
-          val global: self.global.type with NscInteractiveGlobal = self.global.asInstanceOf[self.global.type with NscInteractiveGlobal]
+          val global: self.global.type with NscInteractiveGlobal =
+            self.global.asInstanceOf[self.global.type with NscInteractiveGlobal]
         } with ParadiseAnalyzer with NscInteractiveAnalyzer {
-          override def newTyper(context: Context) = new ParadiseTyper(context) with InteractiveTyper
+          override def newTyper(context: Context) =
+            new ParadiseTyper(context) with InteractiveTyper
         }
       } else {
         new { val global: self.global.type = self.global } with ParadiseAnalyzer {
           override protected def findMacroClassLoader(): ClassLoader = {
             val loader = super.findMacroClassLoader
             if (isRepl) {
-              macroLogVerbose("macro classloader: initializing from a REPL classloader: %s".format(global.classPath.asURLs))
+              macroLogVerbose(
+                "macro classloader: initializing from a REPL classloader: %s".format(
+                  global.classPath.asURLs))
               val virtualDirectory = global.settings.outputDirs.getSingleOutput.get
               new scala.reflect.internal.util.AbstractFileClassLoader(virtualDirectory, loader) {}
             } else {
@@ -38,20 +44,28 @@ trait HijackAnalyzer {
         }
       }
     }
-    val globalClass: Class[_] = if (isRepl) global.getClass else if (isInteractive) classOf[NscInteractiveGlobal] else classOf[NscGlobal]
+    val globalClass: Class[_] =
+      if (isRepl) global.getClass
+      else if (isInteractive) classOf[NscInteractiveGlobal]
+      else classOf[NscGlobal]
     val analyzerField = globalClass.getDeclaredField("analyzer")
     analyzerField.setAccessible(true)
     analyzerField.set(global, newAnalyzer)
 
     val phasesSetMapGetter = classOf[NscGlobal].getDeclaredMethod("phasesSet")
-    val phasesSet = phasesSetMapGetter.invoke(global).require[mutable.Set[SubComponent]]
+    val phasesSet          = phasesSetMapGetter.invoke(global).require[mutable.Set[SubComponent]]
     if (phasesSet.exists(_.phaseName == "typer")) { // `scalac -help` doesn't instantiate standard phases
       def subcomponentNamed(name: String) = phasesSet.find(_.phaseName == name).head
-      val oldScs @ List(oldNamer, oldPackageobjects, oldTyper) = List(subcomponentNamed("namer"), subcomponentNamed("packageobjects"), subcomponentNamed("typer"))
-      val newScs = List(newAnalyzer.namerFactory, newAnalyzer.packageObjects, newAnalyzer.typerFactory)
+      val oldScs @ List(oldNamer, oldPackageobjects, oldTyper) = List(
+        subcomponentNamed("namer"),
+        subcomponentNamed("packageobjects"),
+        subcomponentNamed("typer"))
+      val newScs =
+        List(newAnalyzer.namerFactory, newAnalyzer.packageObjects, newAnalyzer.typerFactory)
       def hijackDescription(pt: SubComponent, sc: SubComponent) = {
         val phasesDescMapGetter = classOf[NscGlobal].getDeclaredMethod("phasesDescMap")
-        val phasesDescMap = phasesDescMapGetter.invoke(global).require[mutable.Map[SubComponent, String]]
+        val phasesDescMap =
+          phasesDescMapGetter.invoke(global).require[mutable.Map[SubComponent, String]]
         phasesDescMap(sc) = phasesDescMap(pt)
       }
       oldScs zip newScs foreach { case (pt, sc) => hijackDescription(pt, sc) }

--- a/plugin/src/main/scala/scala/meta/Mirror.scala
+++ b/plugin/src/main/scala/scala/meta/Mirror.scala
@@ -1,0 +1,10 @@
+package scala.meta
+
+object Mirror {
+  def apply(artifacts: Artifact*)(implicit resolver: Resolver): Mirror = {
+    new Mirror {
+      lazy val domain       = Domain(artifacts: _*)(resolver)
+      override def toString = s"""Context(${artifacts.mkString(", ")})($resolver)"""
+    }
+  }
+}

--- a/project/build.scala
+++ b/project/build.scala
@@ -5,29 +5,29 @@ import AssemblyKeys._
 
 object build extends Build {
   lazy val ScalaVersions = Seq("2.11.8")
-  lazy val MetaVersion = "1.2.0-SNAPSHOT"
+  lazy val MetaVersion   = "1.2.0-SNAPSHOT"
 
   lazy val sharedSettings = Defaults.defaultSettings ++ Seq(
-    scalaVersion := ScalaVersions.head,
-    crossVersion := CrossVersion.full,
-    version := "3.0.0-SNAPSHOT",
-    organization := "org.scalameta",
-    description := "Empowers production Scala compiler with latest macro developments",
-    resolvers += Resolver.sonatypeRepo("snapshots"),
-    resolvers += Resolver.sonatypeRepo("releases"),
-    publishMavenStyle := true,
-    publishArtifact in Test := false,
-    scalacOptions ++= Seq("-deprecation", "-feature"),
-    parallelExecution in Test := false, // hello, reflection sync!!
-    logBuffered := false,
-    scalaHome := {
+      scalaVersion := ScalaVersions.head,
+      crossVersion := CrossVersion.full,
+      version := "3.0.0-SNAPSHOT",
+      organization := "org.scalameta",
+      description := "Empowers production Scala compiler with latest macro developments",
+      resolvers += Resolver.sonatypeRepo("snapshots"),
+      resolvers += Resolver.sonatypeRepo("releases"),
+      publishMavenStyle := true,
+      publishArtifact in Test := false,
+      scalacOptions ++= Seq("-deprecation", "-feature"),
+      parallelExecution in Test := false, // hello, reflection sync!!
+      logBuffered := false,
+      scalaHome := {
       val scalaHome = System.getProperty("paradise.scala.home")
       if (scalaHome != null) {
         println(s"Going for custom scala home at $scalaHome")
         Some(file(scalaHome))
       } else None
     }
-  )
+    )
 
   def loadCredentials(): List[Credentials] = {
     val mavenSettingsFile = System.getProperty("maven.settings.file")
@@ -36,13 +36,15 @@ object build extends Build {
       try {
         import scala.xml._
         val settings = XML.loadFile(mavenSettingsFile)
-        def readServerConfig(key: String) = (settings \\ "settings" \\ "servers" \\ "server" \\ key).head.text
-        List(Credentials(
-          "Sonatype Nexus Repository Manager",
-          "oss.sonatype.org",
-          readServerConfig("username"),
-          readServerConfig("password")
-        ))
+        def readServerConfig(key: String) =
+          (settings \\ "settings" \\ "servers" \\ "server" \\ key).head.text
+        List(
+          Credentials(
+            "Sonatype Nexus Repository Manager",
+            "oss.sonatype.org",
+            readServerConfig("username"),
+            readServerConfig("password")
+          ))
       } catch {
         case ex: Exception =>
           println("Failed to load Maven settings from " + mavenSettingsFile + ": " + ex)
@@ -55,65 +57,68 @@ object build extends Build {
   }
 
   lazy val root = Project(
-    id = "root",
-    base = file("root")
-  ) settings (
-    sharedSettings : _*
-  ) settings (
-    packagedArtifacts := Map.empty,
-    aggregate in test := false,
-    test := (test in tests in Test).value
-  ) aggregate (
-    plugin,
-    tests
-  )
+      id = "root",
+      base = file("root")
+    ) settings (
+      sharedSettings: _*
+    ) settings (
+      packagedArtifacts := Map.empty,
+      aggregate in test := false,
+      test := (test in tests in Test).value
+    ) aggregate (
+      plugin,
+      tests
+    )
 
   lazy val plugin = Project(
-    id   = "paradise",
-    base = file("plugin")
-  ) settings (
-    sharedSettings : _*
-  ) settings (
-    assemblySettings : _*
-  ) settings (
-    resourceDirectory in Compile <<= baseDirectory(_ / "src" / "main" / "scala" / "org" / "scalameta" / "paradise" / "embedded"),
-    libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-library" % _),
-    libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _),
-    libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-compiler" % _),
-    libraryDependencies += "org.scalameta" %% "scalameta" % MetaVersion,
-    // NOTE: here we depend on the old paradise to build the new one. this is intended.
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
-    test in assembly := {},
-    logLevel in assembly := Level.Error,
-    jarName in assembly := name.value + "_" + scalaVersion.value + "-" + version.value + "-assembly.jar",
-    assemblyOption in assembly ~= { _.copy(includeScala = false) },
-    Keys.`package` in Compile := {
+      id = "paradise",
+      base = file("plugin")
+    ) settings (
+      sharedSettings: _*
+    ) settings (
+      assemblySettings: _*
+    ) settings (
+      resourceDirectory in Compile <<= baseDirectory(
+        _ / "src" / "main" / "scala" / "org" / "scalameta" / "paradise" / "embedded"),
+      libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-library"  % _),
+      libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect"  % _),
+      libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-compiler" % _),
+      libraryDependencies += "org.scalameta"                  %% "scalameta"     % MetaVersion,
+      // NOTE: here we depend on the old paradise to build the new one. this is intended.
+      addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
+      test in assembly := {},
+      logLevel in assembly := Level.Error,
+      jarName in assembly := name.value + "_" + scalaVersion.value + "-" + version.value + "-assembly.jar",
+      assemblyOption in assembly ~= { _.copy(includeScala = false) },
+      Keys.`package` in Compile := {
       val slimJar = (Keys.`package` in Compile).value
-      val fatJar = new File(crossTarget.value + "/" + (jarName in assembly).value)
-      val _ = assembly.value
+      val fatJar  = new File(crossTarget.value + "/" + (jarName in assembly).value)
+      val _       = assembly.value
       IO.copy(List(fatJar -> slimJar), overwrite = true)
       slimJar
     },
-    packagedArtifact in Compile in packageBin := {
-      val temp = (packagedArtifact in Compile in packageBin).value
+      packagedArtifact in Compile in packageBin := {
+      val temp           = (packagedArtifact in Compile in packageBin).value
       val (art, slimJar) = temp
-      val fatJar = new File(crossTarget.value + "/" + (jarName in assembly).value)
-      val _ = assembly.value
+      val fatJar         = new File(crossTarget.value + "/" + (jarName in assembly).value)
+      val _              = assembly.value
       IO.copy(List(fatJar -> slimJar), overwrite = true)
       (art, slimJar)
     },
-    publishMavenStyle := true,
-    publishArtifact in Test := false,
-    publishTo <<= version { v: String =>
+      publishMavenStyle := true,
+      publishArtifact in Test := false,
+      publishTo <<= version { v: String =>
       val nexus = "https://oss.sonatype.org/"
       if (v.trim.endsWith("SNAPSHOT"))
         Some("snapshots" at nexus + "content/repositories/snapshots")
       else
         Some("releases" at nexus + "service/local/staging/deploy/maven2")
     },
-    pomIncludeRepository := { x => false },
-    pomExtra := (
-      <url>https://github.com/scalameta/paradise</url>
+      pomIncludeRepository := { x =>
+      false
+    },
+      pomExtra := (
+        <url>https://github.com/scalameta/paradise</url>
       <inceptionYear>2012</inceptionYear>
       <licenses>
         <license>
@@ -137,9 +142,9 @@ object build extends Build {
           <url>http://xeno.by</url>
         </developer>
       </developers>
-    ),
-    credentials ++= loadCredentials()
-  )
+      ),
+      credentials ++= loadCredentials()
+    )
 
   lazy val usePluginSettings = Seq(
     scalacOptions in Compile <++= (Keys.`package` in (plugin, Compile)) map { (jar: File) =>
@@ -154,36 +159,40 @@ object build extends Build {
   )
 
   lazy val tests = Project(
-    id   = "tests",
-    base = file("tests")
-  ) settings (
-    sharedSettings ++ usePluginSettings: _*
-  ) settings (
-    libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _),
-    libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-compiler" % _),
-    libraryDependencies += "org.scalameta" %% "scalameta" % MetaVersion,
-    libraryDependencies += "org.scalatest" % "scalatest_2.11" % "3.0.0" % "test",
-    libraryDependencies += "org.scalacheck" % "scalacheck_2.11" % "1.10.2-SNAPSHOT" % "test",
-    scalacOptions += "-Ywarn-unused-import",
-    scalacOptions += "-Xfatal-warnings",
-    publishArtifact in Compile := false,
-    unmanagedSourceDirectories in Test <<= (scalaSource in Test) { (root: File) =>
+      id = "tests",
+      base = file("tests")
+    ) settings (
+      sharedSettings ++ usePluginSettings: _*
+    ) settings (
+      libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect"   % _),
+      libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-compiler"  % _),
+      libraryDependencies += "org.scalameta"                  %% "scalameta"      % MetaVersion,
+      libraryDependencies += "org.scalatest"                  % "scalatest_2.11"  % "3.0.0" % "test",
+      libraryDependencies += "org.scalacheck"                 % "scalacheck_2.11" % "1.10.2-SNAPSHOT" % "test",
+      scalacOptions += "-Ywarn-unused-import",
+      scalacOptions += "-Xfatal-warnings",
+      publishArtifact in Compile := false,
+      unmanagedSourceDirectories in Test <<= (scalaSource in Test) { (root: File) =>
       // TODO: I haven't yet ported negative tests to SBT, so for now I'm excluding them
-      val (anns :: Nil, others) = root.listFiles.toList.partition(_.getName == "annotations")
-      val oldAnns = anns.listFiles.find(_.getName == "old").get
+      val (anns :: Nil, others)      = root.listFiles.toList.partition(_.getName == "annotations")
+      val oldAnns                    = anns.listFiles.find(_.getName == "old").get
       val (oldNegAnns, oldOtherAnns) = oldAnns.listFiles.toList.partition(_.getName == "neg")
-      val newAnns = anns.listFiles.find(_.getName == "new").get
-      val newAllAnns = newAnns.listFiles.toList
-      System.setProperty("sbt.paths.tests.scaladoc", oldAnns.listFiles.toList.filter(_.getName == "scaladoc").head.getAbsolutePath)
+      val newAnns                    = anns.listFiles.find(_.getName == "new").get
+      val newAllAnns                 = newAnns.listFiles.toList
+      System.setProperty(
+        "sbt.paths.tests.scaladoc",
+        oldAnns.listFiles.toList.filter(_.getName == "scaladoc").head.getAbsolutePath)
       others ++ oldOtherAnns ++ newAllAnns
     },
-    fullClasspath in Test := {
-      val testcp = (fullClasspath in Test).value.files.map(_.getAbsolutePath).mkString(java.io.File.pathSeparatorChar.toString)
+      fullClasspath in Test := {
+      val testcp = (fullClasspath in Test).value.files
+        .map(_.getAbsolutePath)
+        .mkString(java.io.File.pathSeparatorChar.toString)
       sys.props("sbt.paths.tests.classpath") = testcp
       (fullClasspath in Test).value
     },
-    scalacOptions ++= Seq()
-    // scalacOptions ++= Seq("-Xprint:typer")
-    // scalacOptions ++= Seq("-Xlog-implicits")
-  )
+      scalacOptions ++= Seq()
+      // scalacOptions ++= Seq("-Xprint:typer")
+      // scalacOptions ++= Seq("-Xlog-implicits")
+    )
 }

--- a/tests/src/main/scala/annotations/new/main/Defs.scala
+++ b/tests/src/main/scala/annotations/new/main/Defs.scala
@@ -28,7 +28,6 @@ class printClass extends scala.annotation.StaticAnnotation {
   }
 }
 
-
 @compileTimeOnly("@identity not expanded")
 class identity extends scala.annotation.StaticAnnotation {
   inline def apply(defn: Any): Any = meta {
@@ -71,9 +70,11 @@ object Helpers {
     val parsedStat = stat.parse[Stat].get
 
     defn match {
-      case  q"..$mods def $name[..$tparams](...$paramss): $tpeopt = { ..${stats: immutable.Seq[Stat]} }" =>
+      case q"""..$mods def $name[..$tparams](...$paramss): $tpeopt = {
+                 ..${ stats: immutable.Seq[Stat] }
+               }""" =>
         q"..$mods def $name[..$tparams](...$paramss): $tpeopt = { ..$stats;  $parsedStat}"
-      case  q"..$mods def $name[..$tparams](...$paramss): $tpeopt = $expr" =>
+      case q"..$mods def $name[..$tparams](...$paramss): $tpeopt = $expr" =>
         q"..$mods def $name[..$tparams](...$paramss): $tpeopt = { $expr; $parsedStat  }"
     }
 

--- a/tests/src/main/scala/annotations/new/main/Macros.scala
+++ b/tests/src/main/scala/annotations/new/main/Macros.scala
@@ -7,6 +7,7 @@ import scala.meta._
 class main extends scala.annotation.StaticAnnotation {
   inline def apply(defn: Any): Any = meta {
     val q"object $name { ..$stats }" = defn
+
     val main = q"""
       def main(args: Array[String]): Unit = { ..$stats }
     """

--- a/tests/src/main/scala/annotations/new/main/MacrosWithParams.scala
+++ b/tests/src/main/scala/annotations/new/main/MacrosWithParams.scala
@@ -6,8 +6,9 @@ import scala.meta._
 @compileTimeOnly("@mainWithParams not expanded")
 class mainWithParams(greeting: String) extends scala.annotation.StaticAnnotation {
   inline def apply(defn: Any): Any = meta {
-    val q"new $_($greeting)" = this
+    val q"new $_($greeting)"         = this
     val q"object $name { ..$stats }" = defn
+
     val main = q"""
       def main(args: Array[String]): Unit = {
         println($greeting)

--- a/tests/src/main/scala/annotations/old/argumentative.scala
+++ b/tests/src/main/scala/annotations/old/argumentative.scala
@@ -10,7 +10,12 @@ object argumentativeMacro {
       annottees.map(_.tree).toList match {
         case ModuleDef(mods, name, Template(parents, self, body)) :: Nil =>
           val Apply(Select(Apply(_, List(x, y)), _), _) = c.macroApplication
-          val toStringMethod = DefDef(Modifiers(OVERRIDE), TermName("toString"), List(), List(List()), TypeTree(), Literal(Constant(s"$x $y")))
+          val toStringMethod = DefDef(Modifiers(OVERRIDE),
+                                      TermName("toString"),
+                                      List(),
+                                      List(List()),
+                                      TypeTree(),
+                                      Literal(Constant(s"$x $y")))
           ModuleDef(mods, name, Template(parents, self, body :+ toStringMethod))
       }
     }

--- a/tests/src/main/scala/annotations/old/doubler.scala
+++ b/tests/src/main/scala/annotations/old/doubler.scala
@@ -8,14 +8,17 @@ object doublerMacro {
     val result = {
       def double[T <: Name](name: T): T = {
         val sdoubled = name.toString + name.toString
-        val doubled = if (name.isTermName) TermName(sdoubled) else TypeName(sdoubled)
+        val doubled  = if (name.isTermName) TermName(sdoubled) else TypeName(sdoubled)
         doubled.asInstanceOf[T]
       }
       annottees.map(_.tree).toList match {
-        case ClassDef(mods, name, tparams, impl) :: rest => ClassDef(mods, double(name), tparams, impl) :: rest
+        case ClassDef(mods, name, tparams, impl) :: rest =>
+          ClassDef(mods, double(name), tparams, impl) :: rest
         case ModuleDef(mods, name, impl) :: rest => ModuleDef(mods, double(name), impl) :: rest
-        case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest => DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
-        case TypeDef(mods, name, tparams, rhs) :: rest => TypeDef(mods, double(name), tparams, rhs) :: rest
+        case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest =>
+          DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
+        case TypeDef(mods, name, tparams, rhs) :: rest =>
+          TypeDef(mods, double(name), tparams, rhs) :: rest
         case ValDef(mods, name, tpt, rhs) :: rest => ValDef(mods, double(name), tpt, rhs) :: rest
       }
     }

--- a/tests/src/main/scala/annotations/old/explorer.scala
+++ b/tests/src/main/scala/annotations/old/explorer.scala
@@ -15,7 +15,12 @@ object explorerMacro {
     val result = {
       annottees.map(_.tree).toList match {
         case ModuleDef(mods, name, Template(parents, self, body)) :: Nil =>
-          val toStringMethod = DefDef(Modifiers(OVERRIDE), TermName("toString"), List(), List(List()), TypeTree(), Literal(Constant(explore())))
+          val toStringMethod = DefDef(Modifiers(OVERRIDE),
+                                      TermName("toString"),
+                                      List(),
+                                      List(List()),
+                                      TypeTree(),
+                                      Literal(Constant(explore())))
           ModuleDef(mods, name, Template(parents, self, body :+ toStringMethod))
       }
     }

--- a/tests/src/main/scala/annotations/old/funny.scala
+++ b/tests/src/main/scala/annotations/old/funny.scala
@@ -8,16 +8,17 @@ object funnyMacro {
     val (annottee: MemberDef) :: (expandee: MemberDef) :: rest = annottees.map(_.tree).toList
     def funnify[T <: Name](name: T): T = {
       val sfunnified = name.toString + annottee.name.toString
-      val funnified = if (name.isTermName) TermName(sfunnified) else TypeName(sfunnified)
+      val funnified  = if (name.isTermName) TermName(sfunnified) else TypeName(sfunnified)
       funnified.asInstanceOf[T]
     }
     val expandee1 = {
       expandee match {
         case ClassDef(mods, name, tparams, impl) => ClassDef(mods, funnify(name), tparams, impl)
-        case ModuleDef(mods, name, impl) => ModuleDef(mods, funnify(name), impl)
-        case DefDef(mods, name, tparams, vparamss, tpt, rhs) => DefDef(mods, funnify(name), tparams, vparamss, tpt, rhs)
+        case ModuleDef(mods, name, impl)         => ModuleDef(mods, funnify(name), impl)
+        case DefDef(mods, name, tparams, vparamss, tpt, rhs) =>
+          DefDef(mods, funnify(name), tparams, vparamss, tpt, rhs)
         case TypeDef(mods, name, tparams, rhs) => TypeDef(mods, funnify(name), tparams, rhs)
-        case ValDef(mods, name, tpt, rhs) => ValDef(mods, funnify(name), tpt, rhs)
+        case ValDef(mods, name, tpt, rhs)      => ValDef(mods, funnify(name), tpt, rhs)
       }
     }
     c.Expr[Any](Block(expandee1 :: rest, Literal(Constant(()))))

--- a/tests/src/main/scala/annotations/old/hello.scala
+++ b/tests/src/main/scala/annotations/old/hello.scala
@@ -8,7 +8,12 @@ object helloMacro {
     val result = {
       annottees.map(_.tree).toList match {
         case ModuleDef(mods, name, Template(parents, self, body)) :: Nil =>
-          val helloMethod = DefDef(NoMods, TermName("hello"), List(), List(List()), TypeTree(), Literal(Constant("hello")))
+          val helloMethod = DefDef(NoMods,
+                                   TermName("hello"),
+                                   List(),
+                                   List(List()),
+                                   TypeTree(),
+                                   Literal(Constant("hello")))
           ModuleDef(mods, name, Template(parents, self, body :+ helloMethod))
       }
     }

--- a/tests/src/main/scala/annotations/old/pretty.scala
+++ b/tests/src/main/scala/annotations/old/pretty.scala
@@ -9,7 +9,12 @@ object prettyMacro {
     val result = {
       annottees.map(_.tree).toList match {
         case ModuleDef(mods, name, Template(parents, self, body)) :: Nil =>
-          val toStringMethod = DefDef(Modifiers(OVERRIDE), TermName("toString"), List(), List(List()), TypeTree(), Literal(Constant(name.toString)))
+          val toStringMethod = DefDef(Modifiers(OVERRIDE),
+                                      TermName("toString"),
+                                      List(),
+                                      List(List()),
+                                      TypeTree(),
+                                      Literal(Constant(name.toString)))
           ModuleDef(mods, name, Template(parents, self, body :+ toStringMethod))
       }
     }

--- a/tests/src/main/scala/annotations/old/shove.scala
+++ b/tests/src/main/scala/annotations/old/shove.scala
@@ -25,7 +25,11 @@ object shoveMacro {
                   List(),
                   List(List(ValDef(Modifiers(PARAM), TermName("x"), victim, EmptyTree))),
                   TypeTree(),
-                  Block(List(Apply(Select(Super(This(typeNames.EMPTY), typeNames.EMPTY), termNames.CONSTRUCTOR), List())), Literal(Constant(())))
+                  Block(List(
+                          Apply(Select(Super(This(typeNames.EMPTY), typeNames.EMPTY),
+                                       termNames.CONSTRUCTOR),
+                                List())),
+                        Literal(Constant(())))
                 ),
                 ValDef(mods, name, tpt, rhs)
               )

--- a/tests/src/main/scala/annotations/old/simulacrum.scala
+++ b/tests/src/main/scala/annotations/old/simulacrum.scala
@@ -5,7 +5,8 @@ import scala.annotation.StaticAnnotation
 object simulacrumMacro {
   def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
-    if (annottees.head.tree.getClass.getName.contains("DocDef")) c.abort(c.enclosingPosition, "annottee is a DocDef")
+    if (annottees.head.tree.getClass.getName.contains("DocDef"))
+      c.abort(c.enclosingPosition, "annottee is a DocDef")
     c.Expr[Any](Block(annottees.map(_.tree).toList, Literal(Constant(()))))
   }
 }

--- a/tests/src/main/scala/annotations/old/social.scala
+++ b/tests/src/main/scala/annotations/old/social.scala
@@ -9,10 +9,17 @@ object socialMacros {
     val result = {
       annottees.map(_.tree).toList match {
         case ClassDef(mods, name, tparams, Template(parents, self, body)) :: rest =>
-          val beforeToString = body.collect{ case ddef @ DefDef(_, name, _, _, _, _) if name == TermName("toString") => ddef }
+          val beforeToString = body.collect {
+            case ddef @ DefDef(_, name, _, _, _, _) if name == TermName("toString") => ddef
+          }
           val List(DefDef(_, _, _, _, _, Literal(Constant(before: String)))) = beforeToString
-          val after = before + "+1"
-          val afterToString = DefDef(Modifiers(OVERRIDE), TermName("toString"), List(), List(List()), TypeTree(), Literal(Constant(after)))
+          val after                                                          = before + "+1"
+          val afterToString = DefDef(Modifiers(OVERRIDE),
+                                     TermName("toString"),
+                                     List(),
+                                     List(List()),
+                                     TypeTree(),
+                                     Literal(Constant(after)))
           val body1 = body.diff(beforeToString) :+ afterToString
           ClassDef(mods, name, tparams, Template(parents, self, body1)) :: rest
       }
@@ -25,7 +32,8 @@ object socialMacros {
       annottees.map(_.tree).toList match {
         case ClassDef(mods, name, tparams, impl) :: rest =>
           def plusOne = Apply(Select(New(Ident(TypeName("plusOne"))), termNames.CONSTRUCTOR), Nil)
-          val mods1 = Modifiers(mods.flags, mods.privateWithin, mods.annotations :+ plusOne :+ plusOne)
+          val mods1 =
+            Modifiers(mods.flags, mods.privateWithin, mods.annotations :+ plusOne :+ plusOne)
           ClassDef(mods1, name, tparams, impl) :: rest
       }
     }

--- a/tests/src/test/scala/ReplSuite.scala
+++ b/tests/src/test/scala/ReplSuite.scala
@@ -12,13 +12,22 @@ trait ReplSuite extends ToolSuite with DisableScalaColor {
     s.classpath.value = sys.props("sbt.paths.tests.classpath")
     s.plugin.value = List(sys.props("sbt.paths.plugin.jar"))
     val lines = ILoop.runForTranscript(code, s).lines.toList
-    lines.drop(3).dropRight(2).map(_.replaceAll("\\s+$","")).mkString("\n").trim.stripSuffix("scala>").trim
+    lines
+      .drop(3)
+      .dropRight(2)
+      .map(_.replaceAll("\\s+$", ""))
+      .mkString("\n")
+      .trim
+      .stripSuffix("scala>")
+      .trim
   }
 
   private def replViaReplGlobal(code: String): String = {
     val lines = code.trim.stripMargin.split(EOL)
     val input = lines.mkString(EOL) + EOL
-    val (exitCode, output) = runRepl(input, options => { MainGenericRunner.main(options ++ Array("-Xnojline")); sys.exit(0) })
+    val (exitCode, output) = runRepl(input, options => {
+      MainGenericRunner.main(options ++ Array("-Xnojline")); sys.exit(0)
+    })
     if (exitCode != 0) fail("repl invocation has failed:" + EOL + output)
     val result = {
       // Example output:
@@ -48,7 +57,7 @@ trait ReplSuite extends ToolSuite with DisableScalaColor {
       // scala> :quit
       // ===================
       val unwrapped = output.split(EOL).drop(3).dropRight(2).mkString(EOL)
-      var i = 0
+      var i         = 0
       """(scala> |     \| )""".r.replaceAllIn(unwrapped, m => {
         var prefix = unwrapped.substring(m.start, m.end)
         if (prefix == "     | ") prefix = ""
@@ -62,11 +71,14 @@ trait ReplSuite extends ToolSuite with DisableScalaColor {
   }
 
   // TODO: change this to something less ugly
-  private var _repl: String => String = null
+  private var _repl: String => String            = null
   final protected def repl(code: String): String = _repl(code)
 
-  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit pos: Position): Unit = {
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(
+      implicit pos: Position): Unit = {
     super.test(testName + " (ILoop)", testTags: _*)({ this._repl = replViaILoop _; testFun })
-    super.test(testName + " (ReplGlobal)", testTags: _*)({ this._repl = replViaReplGlobal _; testFun })
+    super.test(testName + " (ReplGlobal)", testTags: _*)({
+      this._repl = replViaReplGlobal _; testFun
+    })
   }
 }

--- a/tests/src/test/scala/ToolSuite.scala
+++ b/tests/src/test/scala/ToolSuite.scala
@@ -5,31 +5,39 @@ import java.security.Permission
 
 trait ToolSuite extends FunSuite {
   private def virtualizedPopen(input: String, body: => Unit): (Int, String) = {
-    val inputStream = new ByteArrayInputStream(input.getBytes(Charset.forName("UTF-8")))
+    val inputStream   = new ByteArrayInputStream(input.getBytes(Charset.forName("UTF-8")))
     val outputStorage = new ByteArrayOutputStream()
-    val outputStream = new PrintStream(outputStorage)
+    val outputStream  = new PrintStream(outputStorage)
     case class SystemExitException(exitCode: Int) extends SecurityException
     val manager = System.getSecurityManager()
     System.setSecurityManager(new SecurityManager {
-      override def checkPermission(permission: Permission): Unit = ()
+      override def checkPermission(permission: Permission): Unit                  = ()
       override def checkPermission(permission: Permission, context: AnyRef): Unit = ()
-      override def checkExit(exitCode: Int): Unit = throw new SystemExitException(exitCode)
+      override def checkExit(exitCode: Int): Unit                                 = throw new SystemExitException(exitCode)
     })
-    try { scala.Console.withIn(inputStream)(scala.Console.withOut(outputStream)(scala.Console.withErr(outputStream)(body))); throw new Exception("failed to capture exit code") }
-    catch { case SystemExitException(exitCode) => outputStream.close(); (exitCode, outputStorage.toString) }
-    finally System.setSecurityManager(manager)
+    try {
+      scala.Console.withIn(inputStream)(
+        scala.Console.withOut(outputStream)(scala.Console.withErr(outputStream)(body)));
+      throw new Exception("failed to capture exit code")
+    } catch {
+      case SystemExitException(exitCode) =>
+        outputStream.close(); (exitCode, outputStorage.toString)
+    } finally System.setSecurityManager(manager)
   }
 
   private def commonOptions: List[String] = {
     val cp = List("-cp", sys.props("sbt.paths.tests.classpath"))
-    val paradise = List("-Xplugin:" + sys.props("sbt.paths.plugin.jar"), "-Xplugin-require:macroparadise")
-    val tempDir = File.createTempFile("temp", System.nanoTime.toString); tempDir.delete(); tempDir.mkdir()
+    val paradise =
+      List("-Xplugin:" + sys.props("sbt.paths.plugin.jar"), "-Xplugin-require:macroparadise")
+    val tempDir = File.createTempFile("temp", System.nanoTime.toString); tempDir.delete();
+    tempDir.mkdir()
     val output = List("-d", tempDir.getAbsolutePath)
     cp ++ paradise ++ output
   }
 
   def runCompiler(sourceDir: File, tool: Array[String] => Unit): (Int, String) = {
-    val sources = sourceDir.listFiles().filter(_.getName.endsWith(".scala")).map(_.getAbsolutePath).toList
+    val sources =
+      sourceDir.listFiles().filter(_.getName.endsWith(".scala")).map(_.getAbsolutePath).toList
     val options = commonOptions ++ sources
     virtualizedPopen("", tool(options.toArray))
   }

--- a/tests/src/test/scala/annotations/new/main/Companion.scala
+++ b/tests/src/test/scala/annotations/new/main/Companion.scala
@@ -4,7 +4,8 @@ trait Bar {
   val k: Int = 3
 }
 
-@classMacro class Foo(id: Int) {
+@classMacro
+class Foo(id: Int) {
   val i: Int = 1
 }
 
@@ -12,6 +13,7 @@ object Foo extends Bar {
   val j: Int = 2
 }
 
-@classMacro class Baz(id: Int) {
+@classMacro
+class Baz(id: Int) {
   val a: String = "abc"
 }

--- a/tests/src/test/scala/annotations/new/main/ExpansionTests.scala
+++ b/tests/src/test/scala/annotations/new/main/ExpansionTests.scala
@@ -50,7 +50,8 @@ class ExpansionTests extends FunSuite {
   test("Verify expansion order") {
     var letters = ""
 
-    @appendB @appendC
+    @appendB
+    @appendC
     def foo() = {
       @appendA
       def bar() = {}
@@ -95,7 +96,8 @@ class ExpansionTests extends FunSuite {
   test("Placebo after expandee should compile and work") {
     var letters = ""
 
-    @appendA @placebo
+    @appendA
+    @placebo
     def bar() = {}
 
     bar()
@@ -106,7 +108,8 @@ class ExpansionTests extends FunSuite {
   test("Placebo before expandee should compile and work") {
     var letters = ""
 
-    @placebo @appendA
+    @placebo
+    @appendA
     def bar() = {}
 
     bar()
@@ -117,7 +120,9 @@ class ExpansionTests extends FunSuite {
   test("Multiple expandees of same kinds with others in between should expand") {
     var letters = ""
 
-    @appendA @identity @appendB
+    @appendA
+    @identity
+    @appendB
     def bar() = {}
 
     bar()
@@ -125,11 +130,11 @@ class ExpansionTests extends FunSuite {
     assert(letters === "ab")
   }
 
- test("Multiple expandees of similar kinds should expand in the correct order") {
-   var letters = ""
+  test("Multiple expandees of similar kinds should expand in the correct order") {
+    var letters = ""
 
-
-   @appendA @appendB
+    @appendA
+    @appendB
     def bar() = {}
 
     bar()
@@ -140,7 +145,8 @@ class ExpansionTests extends FunSuite {
   test("Identity expandee followed by regular expandee should expand correctly") {
     var letters = ""
 
-    @identity @appendA
+    @identity
+    @appendA
     def bar() = {}
 
     bar()
@@ -151,7 +157,8 @@ class ExpansionTests extends FunSuite {
   test("Regular expandee followed by Identity expandee should expand correctly") {
     var letters = ""
 
-    @appendA @identity
+    @appendA
+    @identity
     def bar() = {}
 
     bar()
@@ -162,7 +169,8 @@ class ExpansionTests extends FunSuite {
   test("Placebo in package doesnt accidentally get removed if second") {
     var letters = ""
 
-    @appendA @placebo.appendA
+    @appendA
+    @placebo.appendA
     def bar() = {}
 
     bar()
@@ -173,7 +181,8 @@ class ExpansionTests extends FunSuite {
   test("Placebo in package doesnt accidentally get removed if first") {
     var letters = ""
 
-    @placebo.appendA @appendA
+    @placebo.appendA
+    @appendA
     def bar() = {}
 
     bar()

--- a/tests/src/test/scala/annotations/new/main/TestMods.scala
+++ b/tests/src/test/scala/annotations/new/main/TestMods.scala
@@ -12,11 +12,13 @@ case class Test3()
 @main.identity()
 case class Test4()
 
-@identity object Test5 {
+@identity
+object Test5 {
   override val toString = "Test5"
 }
 
-@main object TestMods {
+@main
+object TestMods {
   case class Message(msg: String)
   println(Message("hello world").msg)
 
@@ -27,18 +29,21 @@ case class Test4()
   println(Test5.toString)
 }
 
-@identity object NamedArg {
+@identity
+object NamedArg {
   case class MyCaseClass(a: Int, b: Int)
   MyCaseClass(0, 1).copy(2, b = 3)
 }
 
-@identity object PatAlternative {
+@identity
+object PatAlternative {
   1 match {
-    case 0 | 1 => true
+    case 0 | 1           => true
     case (2 | 3 | 4 | 5) => false
   }
 }
 
-@identity object ImplicitArg {
+@identity
+object ImplicitArg {
   def add(a: Int)(implicit z: Int = 0) = a + z
 }

--- a/tests/src/test/scala/annotations/new/syntax/Repl.scala
+++ b/tests/src/test/scala/annotations/new/syntax/Repl.scala
@@ -43,4 +43,3 @@ class NewRepl extends ReplSuite {
     """.stripMargin.trim)
   }
 }
-

--- a/tests/src/test/scala/annotations/new/transform/Transform.scala
+++ b/tests/src/test/scala/annotations/new/transform/Transform.scala
@@ -20,10 +20,12 @@ class Transform extends ToolSuite {
     """.stripMargin.trim)
     writer.close
 
-    val (exitCode, output) = runCompiler(testDir, options => Main.main(options ++ Array("-Xprint:typer")))
+    val (exitCode, output) =
+      runCompiler(testDir, options => Main.main(options ++ Array("-Xprint:typer")))
     if (exitCode != 0) fail("compiling a simple inline def failed: " + EOL + output)
 
-    assert(output.trim === """
+    assert(
+      output.trim === """
       |[[syntax trees at end of                     typer]] // test.scala
       |package <empty> {
       |  import scala.meta._;

--- a/tests/src/test/scala/annotations/old/neg/macro-annotation-baddecl/Macros_1.scala
+++ b/tests/src/test/scala/annotations/old/neg/macro-annotation-baddecl/Macros_1.scala
@@ -8,14 +8,17 @@ object doublerMacro {
     val result = {
       def double[T <: Name](name: T): T = {
         val sdoubled = name.toString + name.toString
-        val doubled = if (name.isTermName) newTermName(sdoubled) else newTypeName(sdoubled)
+        val doubled  = if (name.isTermName) newTermName(sdoubled) else newTypeName(sdoubled)
         doubled.asInstanceOf[T]
       }
       annottees.map(_.tree).toList match {
-        case ClassDef(mods, name, tparams, impl) :: rest => ClassDef(mods, double(name), tparams, impl) :: rest
+        case ClassDef(mods, name, tparams, impl) :: rest =>
+          ClassDef(mods, double(name), tparams, impl) :: rest
         case ModuleDef(mods, name, impl) :: rest => ModuleDef(mods, double(name), impl) :: rest
-        case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest => DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
-        case TypeDef(mods, name, tparams, rhs) :: rest => TypeDef(mods, double(name), tparams, rhs) :: rest
+        case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest =>
+          DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
+        case TypeDef(mods, name, tparams, rhs) :: rest =>
+          TypeDef(mods, double(name), tparams, rhs) :: rest
         case ValDef(mods, name, tpt, rhs) :: rest => ValDef(mods, double(name), tpt, rhs) :: rest
       }
     }

--- a/tests/src/test/scala/annotations/old/neg/macro-annotation-badsig/Macros_1.scala
+++ b/tests/src/test/scala/annotations/old/neg/macro-annotation-badsig/Macros_1.scala
@@ -8,14 +8,17 @@ object doublerMacro {
     val result = {
       def double[T <: Name](name: T): T = {
         val sdoubled = name.toString + name.toString
-        val doubled = if (name.isTermName) newTermName(sdoubled) else newTypeName(sdoubled)
+        val doubled  = if (name.isTermName) newTermName(sdoubled) else newTypeName(sdoubled)
         doubled.asInstanceOf[T]
       }
       annottees.map(_.tree).toList match {
-        case ClassDef(mods, name, tparams, impl) :: rest => ClassDef(mods, double(name), tparams, impl) :: rest
+        case ClassDef(mods, name, tparams, impl) :: rest =>
+          ClassDef(mods, double(name), tparams, impl) :: rest
         case ModuleDef(mods, name, impl) :: rest => ModuleDef(mods, double(name), impl) :: rest
-        case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest => DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
-        case TypeDef(mods, name, tparams, rhs) :: rest => TypeDef(mods, double(name), tparams, rhs) :: rest
+        case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest =>
+          DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
+        case TypeDef(mods, name, tparams, rhs) :: rest =>
+          TypeDef(mods, double(name), tparams, rhs) :: rest
         case ValDef(mods, name, tpt, rhs) :: rest => ValDef(mods, double(name), tpt, rhs) :: rest
       }
     }

--- a/tests/src/test/scala/annotations/old/neg/macro-annotation-cyclic-a/Macros_1.scala
+++ b/tests/src/test/scala/annotations/old/neg/macro-annotation-cyclic-a/Macros_1.scala
@@ -7,8 +7,8 @@ object xrefCyclistMacro {
     import c.universe._
     import Flag._
     val name = annottees.head.tree.asInstanceOf[MemberDef].name.toString
-    val a = c.mirror.staticClass("A")
-    val b = c.mirror.staticClass("B")
+    val a    = c.mirror.staticClass("A")
+    val b    = c.mirror.staticClass("B")
     if (name == "A") b.typeSignature
     if (name == "B") a.typeSignature
     c.Expr[Any](Block(annottees.map(_.tree).toList, Literal(Constant())))
@@ -23,7 +23,7 @@ object introspectCyclistMacro {
   def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
     import Flag._
-    val name = annottees.head.tree.asInstanceOf[MemberDef].name.toString
+    val name   = annottees.head.tree.asInstanceOf[MemberDef].name.toString
     val cclass = c.mirror.staticClass("C")
     println(cclass.typeSignature)
     c.Expr[Any](Block(annottees.map(_.tree).toList, Literal(Constant())))

--- a/tests/src/test/scala/annotations/old/neg/macro-annotation-cyclic-b/Macros_1.scala
+++ b/tests/src/test/scala/annotations/old/neg/macro-annotation-cyclic-b/Macros_1.scala
@@ -6,7 +6,7 @@ object introspectCyclistMacro {
   def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
     import Flag._
-    val name = annottees.head.tree.asInstanceOf[MemberDef].name.toString
+    val name   = annottees.head.tree.asInstanceOf[MemberDef].name.toString
     val cclass = c.mirror.staticClass("C")
     cclass.typeSignature
     c.Expr[Any](Block(annottees.map(_.tree).toList, Literal(Constant())))

--- a/tests/src/test/scala/annotations/old/neg/macro-annotation-packageobject/Macros_1.scala
+++ b/tests/src/test/scala/annotations/old/neg/macro-annotation-packageobject/Macros_1.scala
@@ -9,14 +9,17 @@ package pkg {
       val result = {
         def double[T <: Name](name: T): T = {
           val sdoubled = name.toString + name.toString
-          val doubled = if (name.isTermName) newTermName(sdoubled) else newTypeName(sdoubled)
+          val doubled  = if (name.isTermName) newTermName(sdoubled) else newTypeName(sdoubled)
           doubled.asInstanceOf[T]
         }
         annottees.map(_.tree).toList match {
-          case ClassDef(mods, name, tparams, impl) :: rest => ClassDef(mods, double(name), tparams, impl) :: rest
+          case ClassDef(mods, name, tparams, impl) :: rest =>
+            ClassDef(mods, double(name), tparams, impl) :: rest
           case ModuleDef(mods, name, impl) :: rest => ModuleDef(mods, double(name), impl) :: rest
-          case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest => DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
-          case TypeDef(mods, name, tparams, rhs) :: rest => TypeDef(mods, double(name), tparams, rhs) :: rest
+          case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest =>
+            DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
+          case TypeDef(mods, name, tparams, rhs) :: rest =>
+            TypeDef(mods, double(name), tparams, rhs) :: rest
           case ValDef(mods, name, tpt, rhs) :: rest => ValDef(mods, double(name), tpt, rhs) :: rest
         }
       }

--- a/tests/src/test/scala/annotations/old/neg/macro-annotation-toplevel/Macros_1.scala
+++ b/tests/src/test/scala/annotations/old/neg/macro-annotation-toplevel/Macros_1.scala
@@ -8,14 +8,17 @@ object Macros {
     val result = {
       def double[T <: Name](name: T): T = {
         val sdoubled = name.toString + name.toString
-        val doubled = if (name.isTermName) newTermName(sdoubled) else newTypeName(sdoubled)
+        val doubled  = if (name.isTermName) newTermName(sdoubled) else newTypeName(sdoubled)
         doubled.asInstanceOf[T]
       }
       annottees.map(_.tree).toList match {
-        case ClassDef(mods, name, tparams, impl) :: rest => ClassDef(mods, double(name), tparams, impl) :: rest
+        case ClassDef(mods, name, tparams, impl) :: rest =>
+          ClassDef(mods, double(name), tparams, impl) :: rest
         case ModuleDef(mods, name, impl) :: rest => ModuleDef(mods, double(name), impl) :: rest
-        case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest => DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
-        case TypeDef(mods, name, tparams, rhs) :: rest => TypeDef(mods, double(name), tparams, rhs) :: rest
+        case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest =>
+          DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
+        case TypeDef(mods, name, tparams, rhs) :: rest =>
+          TypeDef(mods, double(name), tparams, rhs) :: rest
         case ValDef(mods, name, tpt, rhs) :: rest => ValDef(mods, double(name), tpt, rhs) :: rest
       }
     }

--- a/tests/src/test/scala/annotations/old/neg/macro-annotation-unrecognized-a/Macros_1.scala
+++ b/tests/src/test/scala/annotations/old/neg/macro-annotation-unrecognized-a/Macros_1.scala
@@ -8,14 +8,17 @@ object doublerMacro {
     val result = {
       def double[T <: Name](name: T): T = {
         val sdoubled = name.toString + name.toString
-        val doubled = if (name.isTermName) newTermName(sdoubled) else newTypeName(sdoubled)
+        val doubled  = if (name.isTermName) newTermName(sdoubled) else newTypeName(sdoubled)
         doubled.asInstanceOf[T]
       }
       annottees.map(_.tree).toList match {
-        case ClassDef(mods, name, tparams, impl) :: rest => ClassDef(mods, double(name), tparams, impl) :: rest
+        case ClassDef(mods, name, tparams, impl) :: rest =>
+          ClassDef(mods, double(name), tparams, impl) :: rest
         case ModuleDef(mods, name, impl) :: rest => ModuleDef(mods, double(name), impl) :: rest
-        case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest => DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
-        case TypeDef(mods, name, tparams, rhs) :: rest => TypeDef(mods, double(name), tparams, rhs) :: rest
+        case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest =>
+          DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
+        case TypeDef(mods, name, tparams, rhs) :: rest =>
+          TypeDef(mods, double(name), tparams, rhs) :: rest
         case ValDef(mods, name, tpt, rhs) :: rest => ValDef(mods, double(name), tpt, rhs) :: rest
       }
     }

--- a/tests/src/test/scala/annotations/old/neg/macro-annotation-unrecognized-b/Macros_Test_1.scala
+++ b/tests/src/test/scala/annotations/old/neg/macro-annotation-unrecognized-b/Macros_Test_1.scala
@@ -8,14 +8,17 @@ object doublerMacro {
     val result = {
       def double[T <: Name](name: T): T = {
         val sdoubled = name.toString + name.toString
-        val doubled = if (name.isTermName) newTermName(sdoubled) else newTypeName(sdoubled)
+        val doubled  = if (name.isTermName) newTermName(sdoubled) else newTypeName(sdoubled)
         doubled.asInstanceOf[T]
       }
       annottees.map(_.tree).toList match {
-        case ClassDef(mods, name, tparams, impl) :: rest => ClassDef(mods, double(name), tparams, impl) :: rest
+        case ClassDef(mods, name, tparams, impl) :: rest =>
+          ClassDef(mods, double(name), tparams, impl) :: rest
         case ModuleDef(mods, name, impl) :: rest => ModuleDef(mods, double(name), impl) :: rest
-        case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest => DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
-        case TypeDef(mods, name, tparams, rhs) :: rest => TypeDef(mods, double(name), tparams, rhs) :: rest
+        case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest =>
+          DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
+        case TypeDef(mods, name, tparams, rhs) :: rest =>
+          TypeDef(mods, double(name), tparams, rhs) :: rest
         case ValDef(mods, name, tpt, rhs) :: rest => ValDef(mods, double(name), tpt, rhs) :: rest
       }
     }

--- a/tests/src/test/scala/annotations/old/repl/Repl.scala
+++ b/tests/src/test/scala/annotations/old/repl/Repl.scala
@@ -15,7 +15,8 @@ class Repl extends ReplSuite {
   }
 
   test("ad-hoc macros expand") {
-    assert(repl("""
+    assert(
+      repl("""
       |import scala.language.experimental.macros
       |import scala.reflect.macros.whitebox.Context
       |import scala.annotation.StaticAnnotation

--- a/tests/src/test/scala/annotations/old/run/42/42.scala
+++ b/tests/src/test/scala/annotations/old/run/42/42.scala
@@ -1,5 +1,5 @@
 package issue42
 
-object M {
-  implicit class TimestampOps[@specialized(Int, Long) A](val i: A){}
+object M                                                           {
+  implicit class TimestampOps[@specialized(Int, Long) A](val i: A) {}
 }

--- a/tests/src/test/scala/annotations/old/run/Assorted.scala
+++ b/tests/src/test/scala/annotations/old/run/Assorted.scala
@@ -3,15 +3,16 @@ import scala.reflect.runtime.universe._
 
 class AssortedZoo {
   @doubler def foo(x: Int) = x
-  @doubler val bar = 2
-  @doubler var baz = 3
-  @doubler lazy val bax = 4
+  @doubler val bar         = 2
+  @doubler var baz         = 3
+  @doubler lazy val bax    = 4
   @doubler type T = Int
 }
 
 class Assorted extends FunSuite {
   test("nested") {
-    assert(typeOf[AssortedZoo].decls.sorted.map(_.toString).mkString("\n") === """
+    assert(
+      typeOf[AssortedZoo].decls.sorted.map(_.toString).mkString("\n") === """
       |constructor AssortedZoo
       |method foofoo
       |value barbar
@@ -27,9 +28,9 @@ class Assorted extends FunSuite {
 
   test("local") {
     @doubler def foo(x: Int) = x
-    @doubler val bar = 2
-    @doubler var baz = 3
-    @doubler lazy val bax = 4
+    @doubler val bar         = 2
+    @doubler var baz         = 3
+    @doubler lazy val bax    = 4
     @doubler type T = Int
 
     assert(foofoo(1) === 1)

--- a/tests/src/test/scala/annotations/old/run/Issue09.scala
+++ b/tests/src/test/scala/annotations/old/run/Issue09.scala
@@ -1,7 +1,8 @@
 import org.scalatest.FunSuite
 
 object C09
-@identity @placebo class C09
+@identity
+@placebo class C09
 
 class Issue09 extends FunSuite {
   test("compiles") {}

--- a/tests/src/test/scala/annotations/old/run/Multiple.scala
+++ b/tests/src/test/scala/annotations/old/run/Multiple.scala
@@ -1,7 +1,8 @@
 import org.scalatest.FunSuite
 
 class Multiple extends FunSuite {
-  @doubler @doubler case object D
+  @doubler
+  @doubler case object D
   test("multiple") {
     assert(DDDD.toString === "DDDD")
   }

--- a/tests/src/test/scala/annotations/old/run/NameResolution.scala
+++ b/tests/src/test/scala/annotations/old/run/NameResolution.scala
@@ -1,9 +1,12 @@
 import org.scalatest.FunSuite
 
 @identity1 class C1
-@pkg.identity2 class C2
-@pkg.Module3.identity3 class C3
-@Module4.identity4 class C4
+@pkg.identity2
+class C2
+@pkg.Module3.identity3
+class C3
+@Module4.identity4
+class C4
 
 class NameResolution extends FunSuite {
   import pkg._
@@ -14,13 +17,13 @@ class NameResolution extends FunSuite {
   @identity3 class C3
   @identity4 class C4
 
-  test("verified at compile-time") {
-  }
+  test("verified at compile-time") {}
 }
 
 package pkg {
   // @identity1 class C1
   @identity2 class C2
-  @Module3.identity3 class C3
+  @Module3.identity3
+  class C3
   // @Module4.identity4 class C4
 }

--- a/tests/src/test/scala/annotations/old/run/PackageObject.scala
+++ b/tests/src/test/scala/annotations/old/run/PackageObject.scala
@@ -2,9 +2,9 @@ import org.scalatest.FunSuite
 
 package object pkg1 {
   @doubler def foo(x: Int) = x
-  @doubler val bar = 2
-  @doubler var baz = 3
-  @doubler lazy val bax = 4
+  @doubler val bar         = 2
+  @doubler var baz         = 3
+  @doubler lazy val bax    = 4
   @doubler type T = Int
 }
 

--- a/tests/src/test/scala/annotations/old/run/PackagePackageObject.scala
+++ b/tests/src/test/scala/annotations/old/run/PackagePackageObject.scala
@@ -1,5 +1,4 @@
-package object pkgTest {
-}
+package object pkgTest {}
 
 package pkgTest {
   @deprecated("", "")

--- a/tests/src/test/scala/annotations/old/run/Parameters.scala
+++ b/tests/src/test/scala/annotations/old/run/Parameters.scala
@@ -10,7 +10,10 @@ class ParameterZoo {
 
 class Parameters extends FunSuite {
   test("combo") {
-    assert(typeOf[ParameterZoo].decls.sorted.map(_.toString).mkString("\n") === """
+    assert(
+      typeOf[ParameterZoo].decls.sorted
+        .map(_.toString)
+        .mkString("\n") === """
       |constructor ParameterZoo
       |object С
       |class CTx

--- a/tests/src/test/scala/annotations/old/run/PlaceboAssorted.scala
+++ b/tests/src/test/scala/annotations/old/run/PlaceboAssorted.scala
@@ -3,15 +3,18 @@ import scala.reflect.runtime.universe._
 
 class PlaceboAssortedZoo {
   @placebo def foo(x: Int) = x
-  @placebo val bar = 2
-  @placebo var baz = 3
-  @placebo lazy val bax = 4
+  @placebo val bar         = 2
+  @placebo var baz         = 3
+  @placebo lazy val bax    = 4
   @placebo type T = Int
 }
 
 class PlaceboAssorted extends FunSuite {
   test("nested") {
-    assert(typeOf[PlaceboAssortedZoo].decls.sorted.map(_.toString).mkString("\n") === """
+    assert(
+      typeOf[PlaceboAssortedZoo].decls.sorted
+        .map(_.toString)
+        .mkString("\n") === """
       |constructor PlaceboAssortedZoo
       |method foo
       |type T
@@ -27,9 +30,9 @@ class PlaceboAssorted extends FunSuite {
 
   test("local") {
     @placebo def foo(x: Int) = x
-    @placebo val bar = 2
-    @placebo var baz = 3
-    @placebo lazy val bax = 4
+    @placebo val bar         = 2
+    @placebo var baz         = 3
+    @placebo lazy val bax    = 4
     @placebo type T = Int
 
     assert(foo(1) === 1)

--- a/tests/src/test/scala/annotations/old/run/PlaceboClass.scala
+++ b/tests/src/test/scala/annotations/old/run/PlaceboClass.scala
@@ -3,11 +3,11 @@ package placebo.klass
 import org.scalatest.FunSuite
 import pkg._
 
-@placebo class CPreToplevelNocomp { override def toString = "CPreToplevelNocomp" }
-object CPreToplevelPrecomp { def apply() = new CPreToplevelPrecomp }
-@placebo class CPreToplevelPrecomp { override def toString = "CPreToplevelPrecomp" }
-@placebo class CPreToplevelPostcomp { override def toString = "CPreToplevelPostcomp" }
-object CPreToplevelPostcomp { def apply() = new CPreToplevelPostcomp }
+@placebo class CPreToplevelNocomp   { override def toString = "CPreToplevelNocomp"     }
+object CPreToplevelPrecomp          { def apply()           = new CPreToplevelPrecomp  }
+@placebo class CPreToplevelPrecomp  { override def toString = "CPreToplevelPrecomp"    }
+@placebo class CPreToplevelPostcomp { override def toString = "CPreToplevelPostcomp"   }
+object CPreToplevelPostcomp         { def apply()           = new CPreToplevelPostcomp }
 
 class PlaceboClass extends FunSuite {
   val objects = scala.collection.mutable.ListBuffer[Any]()
@@ -18,40 +18,40 @@ class PlaceboClass extends FunSuite {
   objects += CPostToplevelPrecomp()
   objects += CPostToplevelPostcomp()
 
-  @placebo class CPreMemberNocomp { override def toString = "CPreMemberNocomp" }
-  object CPreMemberPrecomp { def apply() = new CPreMemberPrecomp }
-  @placebo class CPreMemberPrecomp { override def toString = "CPreMemberPrecomp" }
-  @placebo class CPreMemberPostcomp { override def toString = "CPreMemberPostcomp" }
-  object CPreMemberPostcomp { def apply() = new CPreMemberPostcomp }
+  @placebo class CPreMemberNocomp   { override def toString = "CPreMemberNocomp"     }
+  object CPreMemberPrecomp          { def apply()           = new CPreMemberPrecomp  }
+  @placebo class CPreMemberPrecomp  { override def toString = "CPreMemberPrecomp"    }
+  @placebo class CPreMemberPostcomp { override def toString = "CPreMemberPostcomp"   }
+  object CPreMemberPostcomp         { def apply()           = new CPreMemberPostcomp }
   objects += new CPreMemberNocomp()
   objects += CPreMemberPrecomp()
   objects += CPreMemberPostcomp()
   objects += new CPostMemberNocomp()
   objects += CPostMemberPrecomp()
   objects += CPostMemberPostcomp()
-  @placebo class CPostMemberNocomp { override def toString = "CPostMemberNocomp" }
-  object CPostMemberPrecomp { def apply() = new CPostMemberPrecomp }
-  @placebo class CPostMemberPrecomp { override def toString = "CPostMemberPrecomp" }
-  @placebo class CPostMemberPostcomp { override def toString = "CPostMemberPostcomp" }
-  object CPostMemberPostcomp { def apply() = new CPostMemberPostcomp }
+  @placebo class CPostMemberNocomp   { override def toString = "CPostMemberNocomp"     }
+  object CPostMemberPrecomp          { def apply()           = new CPostMemberPrecomp  }
+  @placebo class CPostMemberPrecomp  { override def toString = "CPostMemberPrecomp"    }
+  @placebo class CPostMemberPostcomp { override def toString = "CPostMemberPostcomp"   }
+  object CPostMemberPostcomp         { def apply()           = new CPostMemberPostcomp }
 
   test("combo") {
-    @placebo class CPreLocalNocomp { override def toString = "CPreLocalNocomp" }
-    object CPreLocalPrecomp { def apply() = new CPreLocalPrecomp }
-    @placebo class CPreLocalPrecomp { override def toString = "CPreLocalPrecomp" }
-    @placebo class CPreLocalPostcomp { override def toString = "CPreLocalPostcomp" }
-    object CPreLocalPostcomp { def apply() = new CPreLocalPostcomp }
+    @placebo class CPreLocalNocomp   { override def toString = "CPreLocalNocomp"     }
+    object CPreLocalPrecomp          { def apply()           = new CPreLocalPrecomp  }
+    @placebo class CPreLocalPrecomp  { override def toString = "CPreLocalPrecomp"    }
+    @placebo class CPreLocalPostcomp { override def toString = "CPreLocalPostcomp"   }
+    object CPreLocalPostcomp         { def apply()           = new CPreLocalPostcomp }
     objects += new CPreLocalNocomp()
     objects += CPreLocalPrecomp()
     objects += CPreLocalPostcomp()
     objects += new CPostLocalNocomp()
     objects += CPostLocalPrecomp()
     objects += CPostLocalPostcomp()
-    @placebo class CPostLocalNocomp { override def toString = "CPostLocalNocomp" }
-    object CPostLocalPrecomp { def apply() = new CPostLocalPrecomp }
-    @placebo class CPostLocalPrecomp { override def toString = "CPostLocalPrecomp" }
-    @placebo class CPostLocalPostcomp { override def toString = "CPostLocalPostcomp" }
-    object CPostLocalPostcomp { def apply() = new CPostLocalPostcomp }
+    @placebo class CPostLocalNocomp   { override def toString = "CPostLocalNocomp"     }
+    object CPostLocalPrecomp          { def apply()           = new CPostLocalPrecomp  }
+    @placebo class CPostLocalPrecomp  { override def toString = "CPostLocalPrecomp"    }
+    @placebo class CPostLocalPostcomp { override def toString = "CPostLocalPostcomp"   }
+    object CPostLocalPostcomp         { def apply()           = new CPostLocalPostcomp }
 
     assert(objects.mkString("\n") === """
       |CPreToplevelNocomp

--- a/tests/src/test/scala/annotations/old/run/PlaceboObject.scala
+++ b/tests/src/test/scala/annotations/old/run/PlaceboObject.scala
@@ -5,7 +5,7 @@ import pkg._
 
 @placebo object CPreToplevelNocomp { override def toString = "CPreToplevelNocomp" }
 class CPreToplevelPrecomp
-@placebo object CPreToplevelPrecomp { override def toString = "CPreToplevelPrecomp" }
+@placebo object CPreToplevelPrecomp  { override def toString = "CPreToplevelPrecomp"  }
 @placebo object CPreToplevelPostcomp { override def toString = "CPreToplevelPostcomp" }
 class CPreToplevelPostcomp
 
@@ -20,7 +20,7 @@ class PlaceboClass extends FunSuite {
 
   @placebo object CPreMemberNocomp { override def toString = "CPreMemberNocomp" }
   class CPreMemberPrecomp
-  @placebo object CPreMemberPrecomp { override def toString = "CPreMemberPrecomp" }
+  @placebo object CPreMemberPrecomp  { override def toString = "CPreMemberPrecomp"  }
   @placebo object CPreMemberPostcomp { override def toString = "CPreMemberPostcomp" }
   class CPreMemberPostcomp
   classs += CPreMemberNocomp
@@ -31,14 +31,14 @@ class PlaceboClass extends FunSuite {
   classs += CPostMemberPostcomp
   @placebo object CPostMemberNocomp { override def toString = "CPostMemberNocomp" }
   class CPostMemberPrecomp
-  @placebo object CPostMemberPrecomp { override def toString = "CPostMemberPrecomp" }
+  @placebo object CPostMemberPrecomp  { override def toString = "CPostMemberPrecomp"  }
   @placebo object CPostMemberPostcomp { override def toString = "CPostMemberPostcomp" }
   class CPostMemberPostcomp
 
   test("combo") {
     @placebo object CPreLocalNocomp { override def toString = "CPreLocalNocomp" }
     class CPreLocalPrecomp
-    @placebo object CPreLocalPrecomp { override def toString = "CPreLocalPrecomp" }
+    @placebo object CPreLocalPrecomp  { override def toString = "CPreLocalPrecomp"  }
     @placebo object CPreLocalPostcomp { override def toString = "CPreLocalPostcomp" }
     class CPreLocalPostcomp
     classs += CPreLocalNocomp
@@ -49,7 +49,7 @@ class PlaceboClass extends FunSuite {
     classs += CPostLocalPostcomp
     @placebo object CPostLocalNocomp { override def toString = "CPostLocalNocomp" }
     class CPostLocalPrecomp
-    @placebo object CPostLocalPrecomp { override def toString = "CPostLocalPrecomp" }
+    @placebo object CPostLocalPrecomp  { override def toString = "CPostLocalPrecomp"  }
     @placebo object CPostLocalPostcomp { override def toString = "CPostLocalPostcomp" }
     class CPostLocalPostcomp
 
@@ -78,6 +78,6 @@ class PlaceboClass extends FunSuite {
 
 @placebo object CPostToplevelNocomp { override def toString = "CPostToplevelNocomp" }
 class CPostToplevelPrecomp
-@placebo object CPostToplevelPrecomp { override def toString = "CPostToplevelPrecomp" }
+@placebo object CPostToplevelPrecomp  { override def toString = "CPostToplevelPrecomp"  }
 @placebo object CPostToplevelPostcomp { override def toString = "CPostToplevelPostcomp" }
 class CPostToplevelPostcomp

--- a/tests/src/test/scala/annotations/old/run/PlaceboParameters.scala
+++ b/tests/src/test/scala/annotations/old/run/PlaceboParameters.scala
@@ -10,7 +10,10 @@ class PlaceboParameterZoo {
 
 class PlaceboParameters extends FunSuite {
   test("combo") {
-    assert(typeOf[PlaceboParameterZoo].decls.sorted.map(_.toString).mkString("\n") === """
+    assert(
+      typeOf[PlaceboParameterZoo].decls.sorted
+        .map(_.toString)
+        .mkString("\n") === """
       |constructor PlaceboParameterZoo
       |class C
       |object С

--- a/tests/src/test/scala/annotations/old/run/Recursive.scala
+++ b/tests/src/test/scala/annotations/old/run/Recursive.scala
@@ -3,11 +3,11 @@ package recursive
 import org.scalatest.FunSuite
 import pkg._
 
-@plusTwo class CPreToplevelNocomp { override def toString = "CPreToplevelNocomp" }
-object CPreToplevelPrecomp { def apply() = new CPreToplevelPrecomp }
-@plusTwo class CPreToplevelPrecomp { override def toString = "CPreToplevelPrecomp" }
-@plusTwo class CPreToplevelPostcomp { override def toString = "CPreToplevelPostcomp" }
-object CPreToplevelPostcomp { def apply() = new CPreToplevelPostcomp }
+@plusTwo class CPreToplevelNocomp   { override def toString = "CPreToplevelNocomp"     }
+object CPreToplevelPrecomp          { def apply()           = new CPreToplevelPrecomp  }
+@plusTwo class CPreToplevelPrecomp  { override def toString = "CPreToplevelPrecomp"    }
+@plusTwo class CPreToplevelPostcomp { override def toString = "CPreToplevelPostcomp"   }
+object CPreToplevelPostcomp         { def apply()           = new CPreToplevelPostcomp }
 
 class Recursive extends FunSuite {
   val objects = scala.collection.mutable.ListBuffer[Any]()
@@ -18,40 +18,40 @@ class Recursive extends FunSuite {
   objects += CPostToplevelPrecomp()
   objects += CPostToplevelPostcomp()
 
-  @plusTwo class CPreMemberNocomp { override def toString = "CPreMemberNocomp" }
-  object CPreMemberPrecomp { def apply() = new CPreMemberPrecomp }
-  @plusTwo class CPreMemberPrecomp { override def toString = "CPreMemberPrecomp" }
-  @plusTwo class CPreMemberPostcomp { override def toString = "CPreMemberPostcomp" }
-  object CPreMemberPostcomp { def apply() = new CPreMemberPostcomp }
+  @plusTwo class CPreMemberNocomp   { override def toString = "CPreMemberNocomp"     }
+  object CPreMemberPrecomp          { def apply()           = new CPreMemberPrecomp  }
+  @plusTwo class CPreMemberPrecomp  { override def toString = "CPreMemberPrecomp"    }
+  @plusTwo class CPreMemberPostcomp { override def toString = "CPreMemberPostcomp"   }
+  object CPreMemberPostcomp         { def apply()           = new CPreMemberPostcomp }
   objects += new CPreMemberNocomp()
   objects += CPreMemberPrecomp()
   objects += CPreMemberPostcomp()
   objects += new CPostMemberNocomp()
   objects += CPostMemberPrecomp()
   objects += CPostMemberPostcomp()
-  @plusTwo class CPostMemberNocomp { override def toString = "CPostMemberNocomp" }
-  object CPostMemberPrecomp { def apply() = new CPostMemberPrecomp }
-  @plusTwo class CPostMemberPrecomp { override def toString = "CPostMemberPrecomp" }
-  @plusTwo class CPostMemberPostcomp { override def toString = "CPostMemberPostcomp" }
-  object CPostMemberPostcomp { def apply() = new CPostMemberPostcomp }
+  @plusTwo class CPostMemberNocomp   { override def toString = "CPostMemberNocomp"     }
+  object CPostMemberPrecomp          { def apply()           = new CPostMemberPrecomp  }
+  @plusTwo class CPostMemberPrecomp  { override def toString = "CPostMemberPrecomp"    }
+  @plusTwo class CPostMemberPostcomp { override def toString = "CPostMemberPostcomp"   }
+  object CPostMemberPostcomp         { def apply()           = new CPostMemberPostcomp }
 
   test("combo") {
-    @plusTwo class CPreLocalNocomp { override def toString = "CPreLocalNocomp" }
-    object CPreLocalPrecomp { def apply() = new CPreLocalPrecomp }
-    @plusTwo class CPreLocalPrecomp { override def toString = "CPreLocalPrecomp" }
-    @plusTwo class CPreLocalPostcomp { override def toString = "CPreLocalPostcomp" }
-    object CPreLocalPostcomp { def apply() = new CPreLocalPostcomp }
+    @plusTwo class CPreLocalNocomp   { override def toString = "CPreLocalNocomp"     }
+    object CPreLocalPrecomp          { def apply()           = new CPreLocalPrecomp  }
+    @plusTwo class CPreLocalPrecomp  { override def toString = "CPreLocalPrecomp"    }
+    @plusTwo class CPreLocalPostcomp { override def toString = "CPreLocalPostcomp"   }
+    object CPreLocalPostcomp         { def apply()           = new CPreLocalPostcomp }
     objects += new CPreLocalNocomp()
     objects += CPreLocalPrecomp()
     objects += CPreLocalPostcomp()
     objects += new CPostLocalNocomp()
     objects += CPostLocalPrecomp()
     objects += CPostLocalPostcomp()
-    @plusTwo class CPostLocalNocomp { override def toString = "CPostLocalNocomp" }
-    object CPostLocalPrecomp { def apply() = new CPostLocalPrecomp }
-    @plusTwo class CPostLocalPrecomp { override def toString = "CPostLocalPrecomp" }
-    @plusTwo class CPostLocalPostcomp { override def toString = "CPostLocalPostcomp" }
-    object CPostLocalPostcomp { def apply() = new CPostLocalPostcomp }
+    @plusTwo class CPostLocalNocomp   { override def toString = "CPostLocalNocomp"     }
+    object CPostLocalPrecomp          { def apply()           = new CPostLocalPrecomp  }
+    @plusTwo class CPostLocalPrecomp  { override def toString = "CPostLocalPrecomp"    }
+    @plusTwo class CPostLocalPostcomp { override def toString = "CPostLocalPostcomp"   }
+    object CPostLocalPostcomp         { def apply()           = new CPostLocalPostcomp }
 
     assert(objects.mkString("\n") === """
       |CPreToplevelNocomp+1+1

--- a/tests/src/test/scala/annotations/old/run/TypeArgs.scala
+++ b/tests/src/test/scala/annotations/old/run/TypeArgs.scala
@@ -2,8 +2,10 @@ import org.scalatest.FunSuite
 
 class TypeArgs extends FunSuite {
   test("macro annotations with type args expand") {
-    @shove[Int] val description = "I’m an Int!"
-    @shove[String] val bar = "I’m a String!"
+    @shove[Int]
+    val description = "I’m an Int!"
+    @shove[String]
+    val bar = "I’m a String!"
     assert(5.description === "I’m an Int!")
     assert("foo".bar === "I’m a String!")
   }

--- a/tests/src/test/scala/annotations/old/run/acyclic-a/C.scala
+++ b/tests/src/test/scala/annotations/old/run/acyclic-a/C.scala
@@ -6,6 +6,6 @@ import D._
 class DX extends X
 
 @pretty
-object C {
+object C  {
   class X { override def toString = "CX" }
 }

--- a/tests/src/test/scala/annotations/old/run/acyclic-a/D.scala
+++ b/tests/src/test/scala/annotations/old/run/acyclic-a/D.scala
@@ -5,6 +5,6 @@ import C._
 class CX extends X
 
 @pkg.pretty
-object D {
+object D  {
   class X { override def toString = "DX" }
 }

--- a/tests/src/test/scala/annotations/old/run/acyclic-b/C.scala
+++ b/tests/src/test/scala/annotations/old/run/acyclic-b/C.scala
@@ -7,7 +7,7 @@ object CC {
   val x = new X
 
   @doubler
-  object C {
+  object C  {
     class X { override def toString = "CX" }
   }
 }

--- a/tests/src/test/scala/annotations/old/run/acyclic-b/D.scala
+++ b/tests/src/test/scala/annotations/old/run/acyclic-b/D.scala
@@ -6,7 +6,7 @@ object DD {
   val x = new X
 
   @pkg.doubler
-  object D {
+  object D  {
     class X { override def toString = "DX" }
   }
 }

--- a/tests/src/test/scala/annotations/old/run/companion-symbol-of/A.scala
+++ b/tests/src/test/scala/annotations/old/run/companion-symbol-of/A.scala
@@ -47,8 +47,6 @@
 //   val x = "".toString
 //   F.byname(x); F.hof(() => x); (new { val xx = x }.xx)
 // })
-
-
 // class C1 extends C({
 //   def x = "".toString
 //   F.byname(x)
@@ -115,8 +113,6 @@
 //   def foo = 0
 //   class CInner extends C({foo})
 // })
-
-
 // class CEarly(a: Any) extends {
 //   val early = {def x = "".toString
 //     object Nested { def xx = x}

--- a/tests/src/test/scala/annotations/old/run/companion-symbol-of/B.scala
+++ b/tests/src/test/scala/annotations/old/run/companion-symbol-of/B.scala
@@ -28,7 +28,7 @@ object HasX {
 }
 
 trait NeedsEarly {
- val x: AnyRef
+  val x: AnyRef
 }
 
 object Early extends {
@@ -36,14 +36,14 @@ object Early extends {
   val x = { object EarlyOk extends A[String]; EarlyOk }
 } with NeedsEarly
 
-
 class DoubleTrouble[X](x: AnyRef)(implicit override val tt: TypeTag[X]) extends A[X]
 
-object DoubleOk extends DoubleTrouble[String]({
-  // Drops to this.getClass and is an issue
-  object InnerTrouble extends A[String];
-  InnerTrouble
-})
+object DoubleOk
+    extends DoubleTrouble[String]({
+      // Drops to this.getClass and is an issue
+      object InnerTrouble extends A[String];
+      InnerTrouble
+    })
 
 object Test extends App {
   B
@@ -55,5 +55,3 @@ object Test extends App {
   // locally(Early.x) TODO sort out VerifyError in Early$.<init>
   // DoubleOk         TODO sort out VerifyError in DoubleOk$.<init>
 }
-
-

--- a/tests/src/test/scala/annotations/old/run/companion-symbol-of/C.scala
+++ b/tests/src/test/scala/annotations/old/run/companion-symbol-of/C.scala
@@ -3,4 +3,4 @@ package c
 
 class foo(x: Any) extends annotation.StaticAnnotation
 
-@foo(new AnyRef { }) trait A
+@foo(new AnyRef {}) trait A

--- a/tests/src/test/scala/annotations/old/run/issue10/Test2.scala
+++ b/tests/src/test/scala/annotations/old/run/issue10/Test2.scala
@@ -1,3 +1,5 @@
 package issue10
 
-@pkg.identity @pkg.placebo class C
+@pkg.identity
+@pkg.placebo
+class C

--- a/tests/src/test/scala/annotations/old/run/issue14/Test1.scala
+++ b/tests/src/test/scala/annotations/old/run/issue14/Test1.scala
@@ -3,6 +3,7 @@ package issue14
 trait P1[T] { def foo: T }
 object test1 {
   class PWrapper[T] {
-    @pkg.happytee val self: P1[T] = ???
+    @pkg.happytee
+    val self: P1[T] = ???
   }
 }

--- a/tests/src/test/scala/annotations/old/run/issue14/Test2.scala
+++ b/tests/src/test/scala/annotations/old/run/issue14/Test2.scala
@@ -5,8 +5,9 @@ object test2 {
   class PWrapper[T] {
     import java.util // make sure that macro expansion logic skips import contexts
     import java.lang.reflect
-    val dummy1: util.List[_] = ???
+    val dummy1: util.List[_]   = ???
     val dummy2: reflect.Method = ???
-    @pkg.happytee val self: P2[T] = ???
+    @pkg.happytee
+    val self: P2[T] = ???
   }
 }

--- a/tests/src/test/scala/annotations/old/run/issue48/Test1.scala
+++ b/tests/src/test/scala/annotations/old/run/issue48/Test1.scala
@@ -6,4 +6,3 @@ class Test {
     ()
   }
 }
-

--- a/tests/src/test/scala/annotations/old/run/issue48/Test2.scala
+++ b/tests/src/test/scala/annotations/old/run/issue48/Test2.scala
@@ -1,4 +1,3 @@
 package issue48
 
 @deprecated("", "") case class C()
-

--- a/tests/src/test/scala/annotations/old/run/issue64/Test.scala
+++ b/tests/src/test/scala/annotations/old/run/issue64/Test.scala
@@ -5,5 +5,6 @@ object Test extends App {
   def Foo = ???
   @ann trait Foo[T]
   def Bar = ???
-  @pkg.identity trait Bar[T]
+  @pkg.identity
+  trait Bar[T]
 }

--- a/tests/src/test/scala/annotations/old/scaladoc/ScaladocSuite.scala
+++ b/tests/src/test/scala/annotations/old/scaladoc/ScaladocSuite.scala
@@ -4,12 +4,18 @@ import scala.io.Source
 import scala.tools.nsc.ScalaDoc
 
 class ScaladocSuite extends ToolSuite {
-  val resourceDir = new File(System.getProperty("sbt.paths.tests.scaladoc") + File.separatorChar + "resources")
-  val testDirs = resourceDir.listFiles().filter(_.isDirectory).filter(_.listFiles().nonEmpty).filter(!_.getName().endsWith("_disabled"))
-  testDirs.foreach(testDir => test(testDir.getName){
-    val (exitCode, output) = runCompiler(testDir, options => ScalaDoc.main(options))
-    val actualOutput = exitCode + EOL + output
-    val expectedOutput = Source.fromFile(testDir.getAbsolutePath + ".check").mkString
-    assert(actualOutput === expectedOutput)
+  val resourceDir = new File(
+    System.getProperty("sbt.paths.tests.scaladoc") + File.separatorChar + "resources")
+  val testDirs = resourceDir
+    .listFiles()
+    .filter(_.isDirectory)
+    .filter(_.listFiles().nonEmpty)
+    .filter(!_.getName().endsWith("_disabled"))
+  testDirs.foreach(testDir =>
+    test(testDir.getName) {
+      val (exitCode, output) = runCompiler(testDir, options => ScalaDoc.main(options))
+      val actualOutput       = exitCode + EOL + output
+      val expectedOutput     = Source.fromFile(testDir.getAbsolutePath + ".check").mkString
+      assert(actualOutput === expectedOutput)
   })
 }

--- a/tests/src/test/scala/annotations/old/scaladoc/resources/Simulacrum/Test.scala
+++ b/tests/src/test/scala/annotations/old/scaladoc/resources/Simulacrum/Test.scala
@@ -1,16 +1,21 @@
 import scala.language.higherKinds
 
 /**
- */
-@simulacrum trait Applicative[F[_]] {
+  */
+@simulacrum
+trait Applicative[F[_]] {
   def pure[A](x: A): F[A]
 }
 
 class Test {
   @simulacrum def no1 = ???
-  /** 1 */ @simulacrum def yes1 = ???
+
+  /** 1 */
+  @simulacrum def yes1 = ???
 
   class ann extends scala.annotation.StaticAnnotation
   @ann def no2 = ???
-  /** 2 */ @ann def yes2 = ???
+
+  /** 2 */
+  @ann def yes2 = ???
 }


### PR DESCRIPTION
To reformat the project, run ./bin/scalafmt

Why?  Because our time is better spent on solving problems than discuss
trivia. I admit the output from scalafmt in this diff is not always
perfect, but it's good enough for my personal taste.

The CI enforces that new changes are reformatted with scalafmt.