### PR TITLE
some fixes and tests for imports

### DIFF
--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/LogicalTrees.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/LogicalTrees.scala
@@ -1048,16 +1048,18 @@ trait LogicalTrees { self: ReflectToolkit =>
 
     // ============ ODDS & ENDS ============
 
-    case class ImportSelector(name: l.QualifierName, rename: l.QualifierName)
+    case class ImportSelector(name: l.QualifierName, rename: Option[l.QualifierName])
 
     object Import {
       def unapply(tree: g.Import): Option[(g.Tree, List[l.ImportSelector])] = {
         val g.Import(expr, selectors) = tree
         val lname                     = expr
         val lselectors = selectors.map {
+          case g.ImportSelector(name, _, null, _) =>
+            l.ImportSelector(l.IndeterminateName(name.displayName), None)
           case g.ImportSelector(name, _, rename, _) =>
             l.ImportSelector(l.IndeterminateName(name.displayName),
-                             l.IndeterminateName(rename.displayName))
+                             Some(l.IndeterminateName(rename.displayName)))
         }
         Some(lname, lselectors)
       }

--- a/tests/converter/src/test/scala/Syntactic.scala
+++ b/tests/converter/src/test/scala/Syntactic.scala
@@ -122,6 +122,16 @@ class Syntactic extends ConverterSuite {
   syntactic("val a: Option[(Int, String)] = ???")
   syntactic("val a: T forSome { type T } = ???")
 
+  // imports
+  syntactic("import a._")
+  syntactic("import a.b")
+//  syntactic("import a.{b => b}")
+  syntactic("import a.{b => c, d => e}")
+  syntactic("import a.{b => c, _}")
+  syntactic("import a.{b => _}")
+  syntactic("import a.{b => _, c => _, d, _}")
+  syntactic("import a.{b => c, _ => _}")
+
   // random stuff
   syntactic("case class C()")
   syntactic("object M { override val toString = test5 }")


### PR DESCRIPTION
Note `//  syntactic("import a.{b => b}")` in tests. Interesting that scalac parses `import a.b` and `import a.{b => b}` as `ImportSelector(TermName("b"), 9, TermName("b"), 9)` and `ImportSelector(TermName("b"), 10, TermName("b"), 15)` respectively.

Although final result is correct, any suggestions how to fix this one properly are welcome.