### PR TITLE
Convert Basic TypeDefs.

### DIFF
--- a/plugin/src/main/scala/org/scalameta/paradise/converters/ToMtree.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/converters/ToMtree.scala
@@ -307,6 +307,13 @@ trait ToMtree { self: Converter =>
                 val mrhs     = lrhs.toMtree[m.Term]
                 m.Defn.Def(mmods, mname, mtparams, mparamss, mtpt, mrhs)
 
+              case l.TypeDef(lmods, lname, ltparams, lbody) =>
+                val mmods    = lmods.toMtrees[m.Mod]
+                val mname    = lname.toMtree[m.Type.Name]
+                val mtparams = ltparams.toMtrees[m.Type.Param]
+                val mbody    = lbody.toMtree[m.Type]
+                m.Defn.Type(mmods, mname, mtparams, mbody)
+
               case l.ClassDef(lmods, lname, ltparams, lctor, limpl) =>
                 val mmods    = lmods.toMtrees[m.Mod]
                 val mname    = lname.toMtree[m.Type.Name]

--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/LogicalTrees.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/LogicalTrees.scala
@@ -742,8 +742,10 @@ trait LogicalTrees { self: ReflectToolkit =>
 
     object TypeDef {
       def unapply(
-          tree: g.TypeDef): Option[(List[l.Modifier], l.TypeName, List[g.TypeDef], g.Tree)] = {
-        ???
+          tree: g.TypeDef
+      ): Option[(List[l.Modifier], l.TypeName, List[g.TypeDef], g.Tree)] = {
+        val ltparams = applyBounds(tree.tparams, Nil)
+        Some(l.Modifiers(tree), l.TypeName(tree), ltparams, tree.rhs)
       }
     }
 

--- a/tests/converter/src/test/scala/Syntactic.scala
+++ b/tests/converter/src/test/scala/Syntactic.scala
@@ -156,4 +156,18 @@ class Syntactic extends ConverterSuite {
   syntactic("def add(a: Int)(implicit z: Int = 0) = a + z")
   syntactic("def f(x: => T) = ???")
 
+  // TypeDef
+  syntactic("type Age = Int")
+  syntactic("type Age = Int with Old")
+  syntactic("type Container[T] = List[T]")
+  syntactic("type Container[A <: B] = List[A]")
+  // Can't parse these because they're abstract
+  //  syntactic("type Age >: Int <: Any")
+  //  syntactic("type Age <: Int + Boolean")
+  //  syntactic("type Container[T]")
+  // Can parse these but rhs is TypeBoundsTree, I expected the rhs to be empty.
+  //  syntactic("type Container[T] <: List[T] { def isEmpty: Boolean; type M }")
+  //  syntactic("type Container[T] <: List[T] with Set[T] { def isEmpty: Boolean; type M }")
+  //  syntactic("type Container[T] <: List[T] with Set[T] { def isEmpty: Boolean; type M = Int }")
+  //  syntactic("type Container[T] <: List[T] with Set[T] { def isEmpty: Boolean; type M <: Int }")
 }


### PR DESCRIPTION
Judging from #95, TypeDefs (presumably basic ones)  seems to be a blocker.