### PR TITLE
Packages

### DIFF
--- a/plugin/src/main/scala/org/scalameta/paradise/converters/ToMtree.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/converters/ToMtree.scala
@@ -337,9 +337,9 @@ trait ToMtree { self: Converter =>
               // ============ PKGS ============
 
               case l.PackageDef(lname, lstats) =>
-                val mname  = lname.toMtree[m.Term.Name]
+                val mref   = lname.toMtree[m.Term.Ref]
                 val mstats = lstats.toMtrees[m.Stat]
-                m.Pkg(mname, mstats)
+                m.Pkg(mref, mstats)
 
               // ============ CTORS ============
 

--- a/plugin/src/main/scala/org/scalameta/paradise/reflect/LogicalTrees.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/reflect/LogicalTrees.scala
@@ -782,10 +782,11 @@ trait LogicalTrees { self: ReflectToolkit =>
     // ============ PKGS ============
 
     object PackageDef {
-      def unapply(tree: g.PackageDef): Option[(l.TermName, List[g.Tree])] = {
+      def unapply(tree: g.PackageDef): Option[(g.RefTree, List[g.Tree])] = {
         require(tree.pid.name != nme.EMPTY_PACKAGE_NAME)
         val lstats = toplevelStats(tree.stats)
-        Some((l.TermName(tree.pid), lstats))
+        val lref   = tree.pid
+        Some((lref, lstats))
       }
     }
 

--- a/tests/converter/src/main/scala/ConverterSuite.scala
+++ b/tests/converter/src/main/scala/ConverterSuite.scala
@@ -71,6 +71,8 @@ trait ConverterSuite extends FunSuite {
                   loop(xlhs, ylhs) && loop(xop, yop) && loop(xrhs, yrhs)
                 case (importee"$xfrom => $xto", importee"$yfrom") =>
                   loop(xfrom, yfrom) && xfrom.value == xto.value
+                case (pkg1: Pkg, Source(Seq(pkg2: Pkg))) => // ToMtree wraps packages in Source
+                  loop(pkg1, pkg2)
                 // TODO: Account for `import x, y` being desugared to `import x; import y`.
                 // This is not an easy fix, because we need to process both blocks and templates in a non-trivial way.
                 // I'm leaving this for future work though, because I think this is gonna be a pretty rare occurrence in tests.
@@ -114,10 +116,10 @@ trait ConverterSuite extends FunSuite {
             fail(s"meta parse error: $pos at $message")
         }
       }
-      val convertedMetaTree: m.Stat = {
+      val convertedMetaTree: m.Tree = {
         object converter extends Converter {
           lazy val global: ConverterSuite.this.g.type = ConverterSuite.this.g
-          def apply(gtree: g.Tree): m.Stat            = gtree.toMtree[m.Stat]
+          def apply(gtree: g.Tree): m.Tree            = gtree.toMtree[m.Tree]
         }
         converter(parsedScalacTree)
       }

--- a/tests/converter/src/test/scala/Syntactic.scala
+++ b/tests/converter/src/test/scala/Syntactic.scala
@@ -155,5 +155,5 @@ class Syntactic extends ConverterSuite {
   """)
   syntactic("def add(a: Int)(implicit z: Int = 0) = a + z")
   syntactic("def f(x: => T) = ???")
-
+  syntactic("package a.b { }")
 }


### PR DESCRIPTION
#95 revealed that 15k out of 20k convert errors came from PackageDef. This PR is a good start to shrink that  number.