### PR TITLE
Convert {Pat,Term}.Interpolate, fixes #76.

### DIFF
--- a/plugin/src/main/scala/org/scalameta/paradise/converters/ToMtree.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/converters/ToMtree.scala
@@ -53,6 +53,12 @@ trait ToMtree { self: Converter =>
                 val mname = lname.toMtree[m.Term.Name]
                 m.Term.Select(mpre, mname)
 
+              case l.TermInterpolate(lprefix, lparts, largs) =>
+                val mprefix = lprefix.toMtree[m.Term.Name]
+                val mparts  = lparts.toMtrees[m.Lit]
+                val margs   = largs.toMtrees[m.Term]
+                m.Term.Interpolate(mprefix, mparts, margs)
+
               case l.TermApply(lfun, largs) =>
                 val mfun  = lfun.toMtree[m.Term]
                 val margs = largs.toMtrees[m.Term.Arg]
@@ -282,6 +288,12 @@ trait ToMtree { self: Converter =>
                 val mtargs = ltargs.toMtrees[m.Pat.Type]
                 val margs  = largs.toMtrees[m.Pat.Arg]
                 m.Pat.Extract(mref, mtargs, margs)
+
+              case l.PatInterpolate(lprefix, lparts, largs) =>
+                val mprefix = lprefix.toMtree[m.Term.Name]
+                val mparts  = lparts.toMtrees[m.Lit]
+                val margs   = largs.toMtrees[m.Pat]
+                m.Pat.Interpolate(mprefix, mparts, margs)
 
               case l.PatTyped(llhs, lrhs) =>
                 val mlrhs = llhs.toMtree[m.Pat]

--- a/tests/converter/src/test/scala/org/scalameta/tests/LotsOfProjects.scala
+++ b/tests/converter/src/test/scala/org/scalameta/tests/LotsOfProjects.scala
@@ -70,6 +70,6 @@ object LotsOfProjects extends ConverterSuite {
   def main(args: Array[String]): Unit = {
     val results = getResults
     printResults(results)
-    assert(results.count(_ == "Success") >= 25891) // increment this number as it increases.
+    assert(results.count(_ == "Success") >= 25951) // increment this number as it increases.
   }
 }

--- a/tests/converter/src/test/scala/org/scalameta/tests/Syntactic.scala
+++ b/tests/converter/src/test/scala/org/scalameta/tests/Syntactic.scala
@@ -73,6 +73,7 @@ class Syntactic extends ConverterSuite {
   syntactic("try f(4) catch { case _: Throwable => 4 }")
   syntactic("try f(4) finally println(6)")
   syntactic("try {} finally println(6)")
+  syntactic(""" StringContext("", "", "").bb(c, c) """)
   // TODO: https://github.com/scalameta/paradise/issues/75
   // syntactic("try foo catch bar")
   // TODO: https://github.com/scalameta/paradise/issues/74
@@ -114,6 +115,7 @@ class Syntactic extends ConverterSuite {
   syntactic("a match { case c: Class[T] => c }")
   syntactic("x match { case http.`*`(q) => q }")
   syntactic("x match { case a: A with B => x }")
+  syntactic("""x match { case q"A($a)" => a } """)
   // TODO: https://github.com/scalameta/paradise/issues/113
   // syntactic("val (a, b) = c")
   // syntactic("val (c, matSink: (Int, String)) = (a, b)")


### PR DESCRIPTION
The trick in the end is quite simple, we consult the original source
file contents to see if the user typed StringContext or the interpolator
prefix.