### PR TITLE
update scalac-plugin.xml to be consistent with paradise 2.x

### DIFF
--- a/plugin/src/main/scala/org/scalameta/paradise/embedded/scalac-plugin.xml
+++ b/plugin/src/main/scala/org/scalameta/paradise/embedded/scalac-plugin.xml
@@ -1,4 +1,4 @@
 <plugin>
-  <name>meta-paradise-plugin</name>
+  <name>macro-paradise-plugin</name>
   <classname>org.scalameta.paradise.Plugin</classname>
 </plugin>


### PR DESCRIPTION
No idea whether this could bite us as a backward incompatibility issue,
but I’d prefer not to risk it.