### PR TITLE
Fix typo, retrigger bintray release.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -252,7 +252,7 @@ def parsePullRequestFromCommitMessage: Option[String] = {
   } yield pr
 }
 
-/** Replaces -SNAPSHOT with latest pull request number, if it exists.j */
+/** Replaces -SNAPSHOT with latest pull request number, if it exists. */
 def latestPullRequestVersion(): Option[String] = {
   for {
     _ <- sys.env.get("BINTRAY_API_KEY")


### PR DESCRIPTION
Bintray seems to be unable to create multiple new packages in first
release. I tried re-starting the CI but with no luck. This commit is
only to trigger a second run on create a new package on bintray.