### PR TITLE
Fix #144. Remove unneeded Term.Apply.

### DIFF
--- a/plugin/src/main/scala/org/scalameta/paradise/converters/LogicalTrees.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/converters/LogicalTrees.scala
@@ -1282,15 +1282,10 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
         case _ => (Nil, Nil)
       }
       val edefs = evdefs ::: etdefs
-      val lparents = parents.zipWithIndex.map {
-        case (parent, i) =>
-          val applied        = dissectApplied(parent)
-          val syntacticArgss = applied.argss
-          val argss =
-            if (syntacticArgss.isEmpty)
-              List(List()) // todo dveim don't forget semanticArgss later
-            else syntacticArgss
-          l.Parent(argss.foldLeft(applied.callee)((curr, args) => g.Apply(curr, args)))
+      val lparents = parents.map { parent =>
+        // TODO(dveim) don't forget semanticArgss later
+        val applied = dissectApplied(parent)
+        l.Parent(applied.argss.foldLeft(applied.callee)((curr, args) => g.Apply(curr, args)))
       }
       val lstats = if (userDefinedStats.nonEmpty) Some(templateStats(userDefinedStats)) else None
       l.Template(edefs, lparents, lself, lstats)

--- a/tests/converter/src/test/scala/org/scalameta/tests/Syntactic.scala
+++ b/tests/converter/src/test/scala/org/scalameta/tests/Syntactic.scala
@@ -61,6 +61,7 @@ class Syntactic extends ConverterSuite {
   syntactic("new C#B")
   syntactic("new o.C#B")
   syntactic("new B { }")
+  syntactic("new B() { }")
   syntactic("new B { val a = 3 }")
   syntactic("new B { def f(x: Int): Int = x*x }")
   syntactic("new B(3) { println(5); def f(x: Int): Int = x*x }")


### PR DESCRIPTION
It appears to be possible to distinguish `Foo(){}` from `Foo{}`, but not
`Foo()` from `Foo`. This commit handles the former case. I can't add
a test for it because the ConverterSuite desugars constructors to handle
the latter case.