### PR TITLE
Bump coursier versions

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M14")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15-1")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M14")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15-1")


### PR DESCRIPTION
sbt-ensime does not support M14 at all.

This means any sbt tasks will fail on paradise if you have ensime in your global sbt plugins file