### PR TITLE
Reparse as stats, rather then in a block

### DIFF
--- a/plugin/src/main/scala/org/scalameta/paradise/typechecker/Expanders.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/typechecker/Expanders.scala
@@ -4,6 +4,7 @@ package typechecker
 import scala.meta.internal.converters.Converter
 import org.scalameta.paradise.parser.SyntaxAnalyzer
 
+import scala.meta.Term
 import scala.meta.dialects.Paradise211
 
 trait Expanders extends Converter { self: AnalyzerPlugins =>
@@ -172,7 +173,11 @@ trait Expanders extends Converter { self: AnalyzerPlugins =>
             })
           }
 
-          val stringExpansion = Paradise211(metaExpansion).syntax
+          val stringExpansion = metaExpansion match {
+            case b: Term.Block => Paradise211(b).syntax.stripPrefix("{").stripSuffix("}")
+            case a => Paradise211(a).syntax
+          }
+
           val compiler = new { val global: Expanders.this.global.type = Expanders.this.global }
           with SyntaxAnalyzer
           val parser =

--- a/plugin/src/main/scala/org/scalameta/paradise/typechecker/Expanders.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/typechecker/Expanders.scala
@@ -175,7 +175,7 @@ trait Expanders extends Converter { self: AnalyzerPlugins =>
 
           val stringExpansion = metaExpansion match {
             case b: Term.Block => Paradise211(b).syntax.stripPrefix("{").stripSuffix("}")
-            case a => Paradise211(a).syntax
+            case a             => Paradise211(a).syntax
           }
 
           val compiler = new { val global: Expanders.this.global.type = Expanders.this.global }

--- a/tests/meta/src/main/scala/genLargeNumberOfStats.scala
+++ b/tests/meta/src/main/scala/genLargeNumberOfStats.scala
@@ -1,0 +1,15 @@
+import scala.meta._
+
+class genLargeNumberOfStats {
+  // Not supported
+  // private[foo] val baz = 2;
+  inline def apply(tree: Any): Any = meta {
+    q"""private class Foo;
+        protected final def bar = 2;
+        trait Bar;
+        abstract class Baz;
+        object Baq;
+        type Ban = Int
+      """
+  }
+}

--- a/tests/meta/src/test/scala/compile/Expansion.scala
+++ b/tests/meta/src/test/scala/compile/Expansion.scala
@@ -229,6 +229,11 @@ class Expansion extends FunSuite {
     @tparam[Int]
     class Foo
   }
+
+  test("Private in block return") {
+    @genLargeNumberOfStats
+    class foo
+  }
 }
 
 // Note: We cannot actually wrap this in test()


### PR DESCRIPTION
Fix for #160 

However, this is not a complete fix, as the parser actual requires information about the annotees parent in some circumstances.

The only example of this I have found is package private.

```scala
private[foo] def hi = "hi"
```

This will fail due to `hi` not being in a containing object `foo`

I still think this is better then it was, but I feel a more thought out solution for package private later