### PR TITLE
Gets actual class of presentation compiler

### DIFF
--- a/plugin/src/main/scala/org/scalameta/paradise/typechecker/HijackAnalyzer.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/typechecker/HijackAnalyzer.scala
@@ -46,7 +46,7 @@ trait HijackAnalyzer { self: NscPlugin =>
     }
     val globalClass: Class[_] =
       if (isRepl) global.getClass
-      else if (isInteractive) classOf[NscInteractiveGlobal]
+      else if (isInteractive) global.getClass
       else classOf[NscGlobal]
     val analyzerField = globalClass.getDeclaredField("analyzer")
     analyzerField.setAccessible(true)


### PR DESCRIPTION
Plugin does not switch on in case when IDE actual presentation compiler
inherits from `interactive.Global`. Problem lays in the way how
`analyzer` is replaced with reflection code. Scala for vals creates
private field which is unavailable in descendant class.
So replacing it directly in `interactive.Global` does not override
`analyzer` in actual presentation compiler.