### PR TITLE
Support type defs with companions (#204)

### DIFF
--- a/plugin/src/main/scala-2.11.11/org/scalameta/paradise/typechecker/Namers.scala
+++ b/plugin/src/main/scala-2.11.11/org/scalameta/paradise/typechecker/Namers.scala
@@ -373,7 +373,11 @@ trait Namers { self: AnalyzerPlugins =>
           s"maybeExpandeeCompleter for ${sym.accurateKindString} ${sym.rawname}#${sym.id}"
         override def maybeExpand(): Unit = {
           val companion =
-            if (tree.isInstanceOf[ClassDef]) patchedCompanionSymbolOf(sym, context) else NoSymbol
+            if (tree.isInstanceOf[ClassDef] || tree.isInstanceOf[TypeDef]) {
+              patchedCompanionSymbolOf(sym, context)
+            } else {
+              NoSymbol
+            }
 
           def maybeExpand(annotation: Tree,
                           annottee: Tree,
@@ -389,8 +393,11 @@ trait Namers { self: AnalyzerPlugins =>
               // if we do ban them, we might get spurious compilation errors from non-existent members that could've been generated
               assert(!currentRun.compiles(mann), mann)
               val companion =
-                if (maybeExpandee.isInstanceOf[ClassDef]) patchedCompanionSymbolOf(sym, context)
-                else NoSymbol
+                if (maybeExpandee.isInstanceOf[ClassDef] || tree.isInstanceOf[TypeDef]) {
+                  patchedCompanionSymbolOf(sym, context)
+                } else {
+                  NoSymbol
+                }
               val companionSource =
                 if (!isWeak(companion)) attachedSource(companion) else EmptyTree
               val unsafeExpandees =

--- a/plugin/src/main/scala-2.12.2/org/scalameta/paradise/typechecker/Namers.scala
+++ b/plugin/src/main/scala-2.12.2/org/scalameta/paradise/typechecker/Namers.scala
@@ -379,7 +379,11 @@ trait Namers { self: AnalyzerPlugins =>
           s"maybeExpandeeCompleter for ${sym.accurateKindString} ${sym.rawname}#${sym.id}"
         override def maybeExpand(): Unit = {
           val companion =
-            if (tree.isInstanceOf[ClassDef]) patchedCompanionSymbolOf(sym, context) else NoSymbol
+            if (tree.isInstanceOf[ClassDef] || tree.isInstanceOf[TypeDef]) {
+              patchedCompanionSymbolOf(sym, context)
+            } else {
+              NoSymbol
+            }
 
           def maybeExpand(annotation: Tree,
                           annottee: Tree,
@@ -395,8 +399,11 @@ trait Namers { self: AnalyzerPlugins =>
               // if we do ban them, we might get spurious compilation errors from non-existent members that could've been generated
               assert(!currentRun.compiles(mann), mann)
               val companion =
-                if (maybeExpandee.isInstanceOf[ClassDef]) patchedCompanionSymbolOf(sym, context)
-                else NoSymbol
+                if (maybeExpandee.isInstanceOf[ClassDef] || tree.isInstanceOf[TypeDef]) {
+                  patchedCompanionSymbolOf(sym, context)
+                } else {
+                  NoSymbol
+                }
               val companionSource =
                 if (!isWeak(companion)) attachedSource(companion) else EmptyTree
               val unsafeExpandees =

--- a/plugin/src/main/scala/org/scalameta/paradise/typechecker/Expanders.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/typechecker/Expanders.scala
@@ -203,7 +203,11 @@ trait Expanders extends Converter { self: AnalyzerPlugins =>
         computeExpansion: () => Option[Tree]): Option[List[Tree]] = {
       val sym = original.symbol
       val companion =
-        if (original.isInstanceOf[ClassDef]) patchedCompanionSymbolOf(sym, context) else NoSymbol
+        if (original.isInstanceOf[ClassDef] || original.isInstanceOf[TypeDef]) {
+          patchedCompanionSymbolOf(sym, context)
+        } else {
+          NoSymbol
+        }
       val wasWeak = isWeak(companion)
       val wasTransient = companion == NoSymbol || companion.isSynthetic
       def extract(expanded: Tree): List[Tree] = expanded match {

--- a/tests/meta/src/main/scala/typeWithCompanion.scala
+++ b/tests/meta/src/main/scala/typeWithCompanion.scala
@@ -1,0 +1,12 @@
+import scala.annotation.StaticAnnotation
+import scala.meta._
+
+class typeWithCompanion extends StaticAnnotation {
+  inline def apply(defn: Any): Any = meta {
+    defn match {
+      case Term.Block((t @ Defn.Type(_, _, _, _)) :: (o @ Defn.Object(_, _, _)) :: Nil) =>
+        Term.Block(t :: o :: Nil)
+      case t => abort(s"Type should have companion\n ${t.structure}")
+    }
+  }
+}

--- a/tests/meta/src/main/scala/typeWithoutCompanion.scala
+++ b/tests/meta/src/main/scala/typeWithoutCompanion.scala
@@ -1,0 +1,12 @@
+import scala.annotation.StaticAnnotation
+import scala.meta._
+
+class typeWithoutCompanion extends StaticAnnotation {
+  inline def apply(defn: Any): Any = meta {
+    defn match {
+      case t: Defn.Type => t
+      case _ =>
+        abort("Type should be passed in by itself")
+    }
+  }
+}

--- a/tests/meta/src/test/scala/compile/Expansion.scala
+++ b/tests/meta/src/test/scala/compile/Expansion.scala
@@ -234,6 +234,26 @@ class Expansion extends FunSuite {
     @genLargeNumberOfStats
     class foo
   }
+
+  test("Expansion of type def with companion") {
+    object SomeObject {
+      @identity type A = Int
+      object A
+    }
+  }
+
+  test("Ensure companion is passed into macro with typedef") {
+    object AnotherObject {
+      @typeWithCompanion type A = Int
+      object A
+    }
+  }
+
+  test("Ensure typedefs without companions are not in a block") {
+    object AThirdObject {
+      @typeWithoutCompanion type A = Int
+    }
+  }
 }
 
 // Note: We cannot actually wrap this in test()


### PR DESCRIPTION
This enables macro expansion for types that have companion objects.

Not only will compilation actually succeed with an `@identity` macro, but the companion will be accessible to the macro user exactly how `Defn.Class` companions are handled.

Given that I had to modify code which affects the old scalamacro macros, I have a feeling that they did not support this either. I did not test the old macros, only the scalameta macros.