### PR TITLE
WIP: Deprecate random Term.Block expansion

### DIFF
--- a/plugin/src/main/scala/org/scalameta/paradise/typechecker/Expanders.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/typechecker/Expanders.scala
@@ -174,7 +174,13 @@ trait Expanders extends Converter { self: AnalyzerPlugins =>
           }
 
           val stringExpansion = metaExpansion match {
-            case b: Term.Block => Paradise211(b).syntax.stripPrefix("{").stripSuffix("}")
+            case b @ Term.Block(m.Defn.Class(_, _, _, _, _) :: m.Defn.Object(_, _, _) :: Nil) =>
+              Paradise211(b).syntax.stripPrefix("{").stripSuffix("}")
+            case b: Term.Block =>
+              currentRun.reporting.deprecationWarning(annotationTree.pos,
+                "Expansions returning Term.Block are now deprecated (excluding companion object expansions), " +
+                  "please ensure all expansions input and output the same type")
+              Paradise211(b).syntax.stripPrefix("{").stripSuffix("}")
             case a => Paradise211(a).syntax
           }
 

--- a/tests/meta/src/main/scala/deprecationWarning.scala
+++ b/tests/meta/src/main/scala/deprecationWarning.scala
@@ -1,0 +1,9 @@
+import scala.annotation.StaticAnnotation
+import scala.meta._
+
+class deprecationWarning extends StaticAnnotation {
+  inline def apply(tree: Any): Any = meta {
+    Term.Block(q"println(2)" :: q"println(2)" :: Nil)
+  }
+}
+

--- a/tests/meta/src/test/scala/compile/Expansion.scala
+++ b/tests/meta/src/test/scala/compile/Expansion.scala
@@ -234,6 +234,14 @@ class Expansion extends FunSuite {
     @genLargeNumberOfStats
     class foo
   }
+
+
+  test("deprecation block expansion") {
+    object Foo{
+      @deprecationWarning
+      def bar = 2
+    }
+  }
 }
 
 // Note: We cannot actually wrap this in test()


### PR DESCRIPTION
@xeno-by @olafurpg I would like to add this deprecation, however it appears deprecation warnings are treated as errors in macro expansion? Am I doing something wrong here?