### PR TITLE
Fix #151, don't remove tokens before body for Function0

### DIFF
--- a/plugin/src/main/scala/org/scalameta/paradise/converters/LogicalTrees.scala
+++ b/plugin/src/main/scala/org/scalameta/paradise/converters/LogicalTrees.scala
@@ -123,7 +123,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
         // before: function((x$1, x$2) => x$1 + x$2)
         // after:  function(_ + _)
         case g.Function(vparams, body)
-            if vparams.forall(x =>
+            if vparams.nonEmpty && vparams.forall(x =>
               x.mods.hasFlag(Gflags.SYNTHETIC) &&
                 x.name.startsWith(nme.FRESH_TERM_NAME_PREFIX)) =>
           Some(body)

--- a/tests/converters/src/test/scala/Syntactic.scala
+++ b/tests/converters/src/test/scala/Syntactic.scala
@@ -65,6 +65,7 @@ class Syntactic extends ConverterSuite {
   syntactic("a.foreach(_ => bar())")
   syntactic("a.foreach(_ + _)")
   syntactic("function _")
+  syntactic("() => {}")
   syntactic("throw new A(4)")
   syntactic("try { throw new A(4) } catch { case _: Throwable => 4 } finally { println(6) }")
   syntactic("try f(4) catch { case _: Throwable => 4 } finally println(6)")


### PR DESCRIPTION
This is needed for Slinky (https://github.com/shadaj/slinky), where Function0's in the body of macro annotated classes are very common.